### PR TITLE
Feature/restore qgroups size

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -50,6 +50,7 @@ public class Main : GLib.Object{
 	public string backup_parent_uuid = "";
 
 	public bool btrfs_mode = true;
+	public bool btrfs_qgroups_enabled = false;
 	public bool include_btrfs_home_for_backup = false;
 	public bool include_btrfs_home_for_restore = false;
 	
@@ -3980,6 +3981,9 @@ public class Main : GLib.Object{
 			return;
 		}
 
+		//query quota
+		btrfs_qgroups_enabled = query_subvolume_quotas();
+
 		thread_subvol_info_success = true;
 		thread_subvol_info_running = false;
 		return;
@@ -4049,6 +4053,114 @@ public class Main : GLib.Object{
 			if (subvol != null){
 				subvol.id = long.parse(parts[1]);
 			}
+		}
+
+		return true;
+	}
+
+	public bool query_subvolume_quotas(){
+		bool ok = query_subvolume_quota("@");
+		if (repo.device.uuid != repo.device_home.uuid){
+			ok = ok && query_subvolume_quota("@home");
+		}
+		return ok;
+	}
+
+	public bool query_subvolume_quota(string subvol_name){
+		log_debug("query_subvolume_quota():%s".printf(subvol_name));
+
+		string cmd = "";
+		string std_out;
+		string std_err;
+		int ret_val;
+
+		string options = use_option_raw ? "--raw" : "";
+
+		cmd = "btrfs qgroup show %s '%s'".printf(options, repo.mount_paths[subvol_name]);
+		log_debug(cmd);
+		ret_val = exec_sync(cmd, out std_out, out std_err);
+
+		if (ret_val != 0){
+			if (use_option_raw){
+				use_option_raw = false;
+
+				// try again without --raw option
+				cmd = "btrfs qgroup show '%s'".printf(repo.mount_paths[subvol_name]);
+				log_debug(cmd);
+				ret_val = exec_sync(cmd, out std_out, out std_err);
+			}
+
+			if (ret_val != 0){
+				log_error (std_err);
+				log_error(_("btrfs returned an error") + ": %d".printf(ret_val));
+				log_error(_("Failed to query subvolume quota"));
+				return false;
+			}
+		}
+
+		/* Sample Output:
+		 *
+		qgroupid rfer       excl
+		-------- ----       ----
+		0/5      106496     106496
+		0/257    3825262592 557056
+		0/258    12689408   49152
+		 * */
+
+		foreach(string line in std_out.split("\n")){
+			if (line == null) { continue; }
+
+			string[] parts = line.split(" ");
+			if (parts.length < 3) { continue; }
+			if (parts[0].split("/").length < 2) { continue; }
+
+			int subvol_id = int.parse(parts[0].split("/")[1]);
+
+			Subvolume subvol = null;
+
+			if ((sys_subvolumes.size > 0) && (sys_subvolumes["@"].id == subvol_id)){
+
+				subvol = sys_subvolumes["@"];
+			}
+			else if ((sys_subvolumes.size > 0)
+				&& sys_subvolumes.has_key("@home")
+				&& (sys_subvolumes["@home"].id == subvol_id)){
+
+				subvol = sys_subvolumes["@home"];
+			}
+			else {
+				foreach(var bak in repo.snapshots){
+					foreach(var sub in bak.subvolumes.values){
+						if (sub.id == subvol_id){
+							subvol = sub;
+						}
+					}
+				}
+			}
+
+			if (subvol != null){
+				int part_num = -1;
+				foreach(string part in parts){
+					if (part.strip().length > 0){
+						part_num ++;
+						switch (part_num){
+							case 1:
+								subvol.total_bytes = int64.parse(part);
+								break;
+							case 2:
+								subvol.unshared_bytes = int64.parse(part);
+								break;
+							default:
+								//ignore
+								break;
+						}
+					}
+				}
+			}
+		}
+
+		foreach(var bak in repo.snapshots){
+			bak.update_control_file();
 		}
 
 		return true;

--- a/src/Core/Subvolume.vala
+++ b/src/Core/Subvolume.vala
@@ -166,6 +166,22 @@ public class Subvolume : GLib.Object{
 
 		log_msg("%s: %s (Id:%ld)\n".printf(_("Deleted subvolume"), name, id));
 
+		if (App.btrfs_qgroups_enabled) {
+			if ((id > 0) && (repo != null)){
+				log_msg("%s: 0/%ld".printf(_("Destroying qgroup"), id));
+
+				cmd = "btrfs qgroup destroy 0/%ld '%s'".printf(id, repo.mount_paths[name]);
+				log_debug(cmd);
+				ret_val = exec_sync(cmd, out std_out, out std_err);
+				if (ret_val != 0){
+					log_error(_("Failed to destroy qgroup") + ": '0/%ld'".printf(id));
+					return false;
+				}
+
+				log_msg("%s: 0/%ld\n".printf(_("Destroyed qgroup"), id));
+			}
+		}
+
 		return true;
 	}
 

--- a/src/Gtk/SnapshotListBox.vala
+++ b/src/Gtk/SnapshotListBox.vala
@@ -37,6 +37,8 @@ class SnapshotListBox : Gtk.Box{
 	public Gtk.TreeView treeview;
     private Gtk.TreeViewColumn col_date;
     private Gtk.TreeViewColumn col_tags;
+    private Gtk.TreeViewColumn col_size;
+    private Gtk.TreeViewColumn col_unshared;
     private Gtk.TreeViewColumn col_system;
     private Gtk.TreeViewColumn col_desc;
 	private int treeview_sort_column_index = 0;
@@ -157,6 +159,56 @@ class SnapshotListBox : Gtk.Box{
 		treeview.append_column(col_tags);
 
 		col_tags.clicked.connect(() => {
+			if(treeview_sort_column_index == 2){
+				treeview_sort_column_desc = !treeview_sort_column_desc;
+			}
+			else{
+				treeview_sort_column_index = 2;
+				treeview_sort_column_desc = false;
+			}
+			refresh();
+		});
+
+		//col_size
+		var col = new TreeViewColumn();
+		col.title = _("Size");
+		col.resizable = true;
+		col.min_width = 80;
+		col.clickable = true;
+		var cell_size = new CellRendererText ();
+		cell_size.ellipsize = Pango.EllipsizeMode.END;
+		cell_size.xalign = (float) 1.0;
+		col.pack_start (cell_size, false);
+		col.set_cell_data_func (cell_size, cell_size_render);
+		col_size = col;
+		treeview.append_column(col_size);
+
+		col_size.clicked.connect(() => {
+			if(treeview_sort_column_index == 2){
+				treeview_sort_column_desc = !treeview_sort_column_desc;
+			}
+			else{
+				treeview_sort_column_index = 2;
+				treeview_sort_column_desc = false;
+			}
+			refresh();
+		});
+
+		//col_unshared
+		col = new TreeViewColumn();
+		col.title = _("Unshared");
+		col.resizable = true;
+		col.min_width = 80;
+		col.clickable = true;
+		var cell_unshared = new CellRendererText ();
+		cell_unshared.ellipsize = Pango.EllipsizeMode.END;
+		cell_unshared.xalign = (float) 1.0;
+		col.pack_start (cell_unshared, false);
+		col.set_cell_data_func (cell_unshared, cell_unshared_render);
+		col_unshared = col;
+		treeview.append_column(col_unshared);
+
+		col_unshared.clicked.connect(() => {
 			if(treeview_sort_column_index == 2){
 				treeview_sort_column_desc = !treeview_sort_column_desc;
 			}
@@ -567,6 +619,9 @@ class SnapshotListBox : Gtk.Box{
 			model.append(out iter);
 			model.set (iter, 0, bak);
 		}
+
+		col_size.visible = App.btrfs_qgroups_enabled;
+		col_unshared.visible = App.btrfs_qgroups_enabled;
 
 		treeview.set_model (model);
 		treeview.columns_autosize ();


### PR DESCRIPTION
Refs: [#47](https://github.com/linuxmint/timeshift/issues/47)

This PR mostly restores old behavior:

* feat: Enable display of shared and exclusive sizes
* fix: Destroy qgroups upon snapshot removal (on a system with qgroups enabled, I encountered a lot of 0.00B qgroups (`btrfs qgroup show .`), supposedly caused by timeshift)

Opposing to the former behavior, timeshift does not enable qgroups by itself anymore.

It simply executes `btrfs qgroup show …` and evaluates the exit code.

On success, btrfs qgroups are considered enabled (`App.btrfs_qgroups_enabled = true`), on failure, btrfs qgroups are considered disabled. In the latter case, timeshift neither shows the size columns, nor does it destroy qgroups.

This restores a very important feature for users that _do_ use qgroups.
Other users are practically unaffected (btrfs with disabled qgroups and rsync users).

Screenshot:

![image](https://user-images.githubusercontent.com/913720/201358352-a80ecd82-746e-460d-a4fe-5ad50bb21cdd.png)

This PR is a first proposal. If the maintainers generally agree with the attempt, I plan to cleanup the affected code a bit.

