### PR TITLE
Added extra constraints to BTRFS mode in Supported System Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,25 @@ You can selectively include items for backup from the ***Settings*** window. Sel
   - **@** may be on BTRFS volume and **/home** may be mounted on non-BTRFS partition
   - If swap files are used they should not be located in **@** or **@home** and could instead be stored in their own subvolume, eg **@swap**
   - Other layouts are not supported
+  - Make sure, that you have selected subvolume *@* or */@* for root. You can check that executing script below, and if output is *OK*, then everything is alright.
+
+    ```shell
+    grep -E '^[^#].+/\s+btrfs' /etc/fstab | \
+    grep -oE 'subvol=[^,]+' | \
+    cut -d= -f2 | \
+    grep -qE '^/?@$' && \
+    echo 'OK' || \
+    echo 'Not OK'
+    ```
+
+  - Default BTRFS subvolume must be /. You can make it using script below.
+
+    ```shell
+    MP="$(mktemp -d)"
+    mount | awk '/on \/ type btrfs/{print $1}' | sudo xargs -I{} mount {} "$MP" && \
+    sudo btrfs subvolume set-default 5 "$MP"; \
+    sudo umount "$MP"
+    ```
 
 - **GRUB2** - Bootloader must be GRUB2. GRUB legacy and other bootloaders are not supported.
 


### PR DESCRIPTION
I had non standard subvolume set as a default for by BTRFS filesystem. Timeshift refused to work in this scenario. I have pulled your repository and analyzed sources. After short examination, I have understood, that timeshift mounts filesystem without specifying root as subvolume to use.

```shell
sudo mount /dev/dm-0 /run/timeshift/1234/something
```
instead of

```shell
sudo mount /dev/dm-0 -o subvol=/ /run/timeshift/1234/something
```

The best would be fix that in code and hardcode mounting root of the BTRFS, but I am not really familiar with vala.
So I have added extra documentation to make sure that everyone will be able to fix it easily.

Also, I had `@ubuntu` subvolume set in _/etc/fstab_, while my system root is on `@` subvolume. Viewing current volumes mounts in output of `sudo mount` I can see, that `@` is really mounted, and line in _/etc/fstab_ was ignored. I was really surprised, never seen before that /etc/fstab is ignored. But anyway, that also breaks timeshift. So we have to make sure, that exactly `@` or `/@` is set in subvol option in _/etc/fstab_