### PR TITLE
Update Device.vala to prevent disc full issues

### DIFF
--- a/src/Utility/Device.vala
+++ b/src/Utility/Device.vala
@@ -119,7 +119,7 @@ public class Device : GLib.Object{
 	
 	public uint64 free_bytes{
 		get{
-			return (used_bytes == 0) ? 0 : (size_bytes - used_bytes);
+			return (used_bytes == 0) ? 0 : (available_bytes);
 		}
 	}
 


### PR DESCRIPTION
Changing to available_bytes instead of calculating the free bytes from (size_bytes - used_bytes) respects potential reserved space for "for root only" e.g. on ext4 file systems. It should prevent running out of space in the unfavorable cases having the timeshift archive located on the actual root file system.