### PR TITLE
src/Utility: fix deprecated Thread.create usage

### DIFF
--- a/src/Utility/AsyncTask.vala
+++ b/src/Utility/AsyncTask.vala
@@ -144,7 +144,7 @@ public abstract class AsyncTask : GLib.Object{
 
 			try {
 				//start thread for reading output stream
-				Thread.create<void> (read_stdout, true);
+				new Thread<void>.try ("async-task-stdout-reader", () => {read_stdout();});
 			} catch (Error e) {
 				log_error ("AsyncTask.begin():create_thread:read_stdout()");
 				log_error (e.message);
@@ -152,7 +152,7 @@ public abstract class AsyncTask : GLib.Object{
 
 			try {
 				//start thread for reading error stream
-				Thread.create<void> (read_stderr, true);
+				new Thread<void>.try ("async-task-stderr-reader", () => {read_stderr();});
 			} catch (Error e) {
 				log_error ("AsyncTask.begin():create_thread:read_stderr()");
 				log_error (e.message);

--- a/src/Utility/TimeoutCounter.vala
+++ b/src/Utility/TimeoutCounter.vala
@@ -44,7 +44,7 @@ public class TimeoutCounter : GLib.Object {
 			
 		try {
 			active = true;
-			Thread.create<void> (start_counter_thread, true);
+			new Thread<void>.try ("timeout-counter",() => { start_counter_thread();});
 		}
 		catch (Error e) {
 			log_error (e.message);
@@ -58,7 +58,7 @@ public class TimeoutCounter : GLib.Object {
 			
 		try {
 			active = true;
-			Thread.create<void> (start_counter_thread, true);
+			new Thread<void>.try ("timeout-counter", () => {start_counter_thread();});
 		}
 		catch (Error e) {
 			log_error (e.message);


### PR DESCRIPTION
This fix was only compile-tested.