### PR TITLE
Fix segmentation fault

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3433,10 +3433,10 @@ public class Main : GLib.Object{
 			// find devices from uuid
 			Device dev = null;
 			Device dev_parent = null;
-			if (backup_uuid.length > 0){
+			if (backup_uuid != null && backup_uuid.length > 0){
 				dev = Device.get_device_by_uuid(backup_uuid);
 			}
-			if (backup_parent_uuid.length > 0){
+			if (backup_parent_uuid != null && backup_parent_uuid.length > 0){
 				dev_parent = Device.get_device_by_uuid(backup_parent_uuid);
 			}
 

--- a/src/Core/SnapshotRepo.vala
+++ b/src/Core/SnapshotRepo.vala
@@ -466,7 +466,7 @@ public class SnapshotRepo : GLib.Object{
 		//log_debug("checking selected device");
 
 		if (device == null){
-			if (App.backup_uuid.length == 0){
+			if (App.backup_uuid == null || App.backup_uuid.length == 0){
 				log_debug("device is null");
 				status_message = _("Snapshot device not selected");
 				status_details = _("Select the snapshot device");


### PR DESCRIPTION
Check not only length but also whether backup_uuid or backup_parent_uuid objects are null.

Such a situation occurs when running 'src/timeshift --list' on a system without an initial timeshift installation i.e. just compiled from source.