### PR TITLE
Console: add --version option

### DIFF
--- a/src/Console/AppConsole.vala
+++ b/src/Console/AppConsole.vala
@@ -63,6 +63,11 @@ public class AppConsole : GLib.Object {
 				case "-h":
 					stdout.printf (help_message ());
 					return 0;
+
+				case "--version":
+					stdout.printf (version_message ());
+					return 0;
+
 			}
 		}
 		else if (args.length == 1){
@@ -332,6 +337,11 @@ public class AppConsole : GLib.Object {
 			default:
 				return true;
 		}
+	}
+
+	private static string version_message (){
+		string msg = "%s %s\n".printf( AppName, AppVersion);
+		return msg;
 	}
 
 	private static string help_message (){


### PR DESCRIPTION
This option prints application name and its version. Such an output can be used to automatically generate a man page using the `help2man` utility.

Fixes #96 