### PR TITLE
[WIP] Add support for systemd timers

### DIFF
--- a/files/timeshift.service
+++ b/files/timeshift.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Timeshift Snapshots
+Documentation=man:timeshift(1)
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/timeshift --check --scripted
+
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_SYS_ADMIN CAP_SYS_MODULE CAP_IPC_LOCK CAP_SYS_NICE
+LockPersonality=true
+NoNewPrivileges=false
+PrivateNetwork=true
+ProtectHostname=true
+RestrictAddressFamilies=AF_UNIX
+RestrictRealtime=true

--- a/files/timeshift.timer
+++ b/files/timeshift.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hourly Timeshift check for snapshots
+Documentation=man:timeshift(1)
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/src/makefile
+++ b/src/makefile
@@ -121,6 +121,10 @@ install:
 		mkdir -p "$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES"; \
 		msgfmt --check --verbose -o "$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/${app_name}.mo" ../po/${app_name}-$$lang.po ; \
 	done
+	
+	# systemd timer and service file
+	install -m 0644 ../files/${app_name}.service "$(DESTDIR)/lib/systemd/system/"
+	install -m 0644 ../files/${app_name}.timer "$(DESTDIR)/lib/systemd/system/"
 
 uninstall:
 
@@ -150,3 +154,7 @@ uninstall:
 	# appdata
 	rm -f "$(DESTDIR)$(sharedir)/appdata/${app_name}.appdata.xml" 
 	rm -f "$(DESTDIR)$(sharedir)/metainfo/${app_name}.appdata.xml"
+	
+	# systemd timer and service file
+	rm -f "$(DESTDIR)/lib/systemd/system/${app_name}.service"
+	rm -f "$(DESTDIR)/lib/systemd/system/${app_name}.timer"


### PR DESCRIPTION
Hello!

I previously sent a pull request for teejays branch a couple of years ago, but they were never merged. This would solve issue #31 but I haven't tested these changes myself in a couple of years now, and I'm currently not using timeshift. I've added changes to the makefile so the files get installed in the correct location, but I haven't tried these myself. It should be as easy as just running `systemctl enable timeshift.timer` after installation though!

This would enable you to remove the dependency on cron, if you want.

Original pull request: https://github.com/teejee2008/timeshift/pull/787 