### PR TITLE
Use an unsafe cast

### DIFF
--- a/src/Gtk/BackupDeviceBox.vala
+++ b/src/Gtk/BackupDeviceBox.vala
@@ -133,7 +133,7 @@ class BackupDeviceBox : Gtk.Box{
 			Device dev;
 			model.get (iter, 0, out dev, -1);
 
-			(cell as Gtk.CellRendererPixbuf).visible = (dev.type == "disk");
+			((Gtk.CellRendererPixbuf)cell).visible = (dev.type == "disk");
 			
 		});
 
@@ -144,9 +144,9 @@ class BackupDeviceBox : Gtk.Box{
 			bool selected;
 			model.get (iter, 0, out dev, 3, out selected, -1);
 
-			(cell as Gtk.CellRendererToggle).active = selected;
+			((Gtk.CellRendererToggle)cell).active = selected;
 
-			(cell as Gtk.CellRendererToggle).visible =
+			((Gtk.CellRendererToggle)cell).visible =
 				(dev.size_bytes > 10 * KB) && (dev.type != "disk") && (dev.children.size == 0);
 		});
 
@@ -175,10 +175,10 @@ class BackupDeviceBox : Gtk.Box{
 				if (txt.length == 0){
 					txt = "%s Disk".printf(format_file_size(dev.size_bytes));
 				}
-				(cell as Gtk.CellRendererText).text = txt.strip();
+				((Gtk.CellRendererText)cell).text = txt.strip();
 			}
 			else {
-				(cell as Gtk.CellRendererText).text = dev.kname;
+				((Gtk.CellRendererText)cell).text = dev.kname;
 			}
 
 			//(cell as Gtk.CellRendererText).sensitive = (dev.type != "disk");
@@ -192,7 +192,7 @@ class BackupDeviceBox : Gtk.Box{
 		col.set_cell_data_func(cell_text, (cell_layout, cell, model, iter)=>{
 			Device dev;
 			model.get (iter, 0, out dev, -1);
-			(cell as Gtk.CellRendererText).text = dev.fstype;
+			((Gtk.CellRendererText)cell).text = dev.fstype;
 
 			//(cell as Gtk.CellRendererText).sensitive = (dev.type != "disk");
 		});
@@ -206,7 +206,7 @@ class BackupDeviceBox : Gtk.Box{
 			Device dev;
 			model.get (iter, 0, out dev, -1);
 
-			(cell as Gtk.CellRendererText).text =
+			((Gtk.CellRendererText)cell).text =
 					(dev.size_bytes > 0) ? format_file_size(dev.size_bytes, false, "", true, 0) : "";
 		});
 
@@ -220,14 +220,14 @@ class BackupDeviceBox : Gtk.Box{
 			model.get (iter, 0, out dev, -1);
 
 			if (dev.type == "disk"){
-				(cell as Gtk.CellRendererText).text = "";
+				((Gtk.CellRendererText)cell).text = "";
 			}
 			else{
-				(cell as Gtk.CellRendererText).text =
+				((Gtk.CellRendererText)cell).text =
 					(dev.free_bytes > 0) ? format_file_size(dev.free_bytes, false, "", true, 0) : "";
 			}
 
-			(cell as Gtk.CellRendererText).sensitive = (dev.type != "disk");
+			((Gtk.CellRendererText)cell).sensitive = (dev.type != "disk");
 		});
 
 		// name
@@ -240,13 +240,13 @@ class BackupDeviceBox : Gtk.Box{
 			model.get (iter, 0, out dev, -1);
 
 			if (dev.type == "disk"){
-				(cell as Gtk.CellRendererText).text = "";
+				((Gtk.CellRendererText)cell).text = "";
 			}
 			else{
-				(cell as Gtk.CellRendererText).text = dev.partlabel;
+				((Gtk.CellRendererText)cell).text = dev.partlabel;
 			}
 
-			(cell as Gtk.CellRendererText).sensitive = (dev.type != "disk");
+			((Gtk.CellRendererText)cell).sensitive = (dev.type != "disk");
 		});
 
 		// label
@@ -259,13 +259,13 @@ class BackupDeviceBox : Gtk.Box{
 			model.get (iter, 0, out dev, -1);
 
 			if (dev.type == "disk"){
-				(cell as Gtk.CellRendererText).text = "";
+				((Gtk.CellRendererText)cell).text = "";
 			}
 			else{
-				(cell as Gtk.CellRendererText).text = dev.label;
+				((Gtk.CellRendererText)cell).text = dev.label;
 			}
 
-			(cell as Gtk.CellRendererText).sensitive = (dev.type != "disk");
+			((Gtk.CellRendererText)cell).sensitive = (dev.type != "disk");
 		});
 		
 		// buffer

--- a/src/Gtk/BootOptionsBox.vala
+++ b/src/Gtk/BootOptionsBox.vala
@@ -91,11 +91,11 @@ class BootOptionsBox : Gtk.Box{
 
 			if (dev.type == "disk"){
 				//log_msg("desc:" + dev.description());
-				(cell as Gtk.CellRendererText).markup =
+				((Gtk.CellRendererText)cell).markup =
 					"<b>%s (MBR)</b>".printf(dev.description_formatted());
 			}
 			else{
-				(cell as Gtk.CellRendererText).text = dev.description();
+				((Gtk.CellRendererText)cell).text = dev.description();
 			}
 		});
 

--- a/src/Gtk/ExcludeAppsBox.vala
+++ b/src/Gtk/ExcludeAppsBox.vala
@@ -100,7 +100,7 @@ class ExcludeAppsBox : Gtk.Box{
 		col.set_cell_data_func(cell_toggle, (cell_layout, cell, model, iter)=>{
 			AppExcludeEntry entry;
 			model.get (iter, 0, out entry, -1);
-			(cell as Gtk.CellRendererToggle).active = entry.enabled;
+			((Gtk.CellRendererToggle)cell).active = entry.enabled;
 		});
 
 		cell_toggle.toggled.connect ((cell_toggle, path) => {
@@ -124,7 +124,7 @@ class ExcludeAppsBox : Gtk.Box{
 			
 			AppExcludeEntry entry;
 			model.get (iter, 0, out entry, -1);
-			(cell as Gtk.CellRendererText).text = entry.name;
+			((Gtk.CellRendererText)cell).text = entry.name;
 		});
 	}
 

--- a/src/Gtk/ExcludeBox.vala
+++ b/src/Gtk/ExcludeBox.vala
@@ -183,7 +183,7 @@ class ExcludeBox : Gtk.Box{
 		col.set_cell_data_func (cell_text, (cell_layout, cell, model, iter)=>{
 			string pattern;
 			model.get (iter, 0, out pattern, -1);
-			(cell as Gtk.CellRendererText).text =
+			((Gtk.CellRendererText)cell).text =
 				pattern.has_prefix("+ ") ? pattern[2:pattern.length] : pattern;
 		});
 
@@ -489,7 +489,7 @@ class ExcludeBox : Gtk.Box{
 		model.set (iter, 2, include);
 		model.set (iter, 3, !include);
 
-		var adj = (treeview as Gtk.Scrollable).get_hadjustment();
+		var adj = ((Gtk.Scrollable)treeview).get_hadjustment();
 		adj.value = adj.upper;
 	}
 

--- a/src/Gtk/ExcludeMessageWindow.vala
+++ b/src/Gtk/ExcludeMessageWindow.vala
@@ -155,7 +155,7 @@ public class ExcludeMessageWindow : Gtk.Dialog{
 		
 		string pattern;
 		model.get (iter, 0, out pattern, -1);
-		(cell as Gtk.CellRendererText).text = pattern.has_prefix("+ ") ? pattern[2:pattern.length] : pattern;
+		((Gtk.CellRendererText)cell).text = pattern.has_prefix("+ ") ? pattern[2:pattern.length] : pattern;
 	}
 
 	private void tv_exclude_add_item(string path){
@@ -175,7 +175,7 @@ public class ExcludeMessageWindow : Gtk.Dialog{
 
 		model.set (iter, 0, path, 1, icon_name);
 
-		Adjustment adj = (tv_exclude as Gtk.Scrollable).get_hadjustment();
+		Adjustment adj = ((Gtk.Scrollable)tv_exclude).get_hadjustment();
 		adj.value = adj.upper;
 	}
 

--- a/src/Gtk/MiscBox.vala
+++ b/src/Gtk/MiscBox.vala
@@ -91,7 +91,7 @@ class MiscBox : Gtk.Box{
 			string txt;
 			model.get (iter, 0, out txt, -1);
 
-			(cell as Gtk.CellRendererText).text = (txt.length == 0) ? _("Custom") : now.format(txt);
+			((Gtk.CellRendererText)cell).text = (txt.length == 0) ? _("Custom") : now.format(txt);
 		});
 		
 		// populate combo

--- a/src/Gtk/RestoreDeviceBox.vala
+++ b/src/Gtk/RestoreDeviceBox.vala
@@ -200,11 +200,11 @@ class RestoreDeviceBox : Gtk.Box{
 			if (dev != null){
 
 				if (dev.type == "disk"){
-					(cell as Gtk.CellRendererPixbuf).icon_name = IconManager.ICON_HARDDRIVE;
+					((Gtk.CellRendererPixbuf)cell).icon_name = IconManager.ICON_HARDDRIVE;
 				}
 			
-				(cell as Gtk.CellRendererPixbuf).sensitive = (dev.type != "disk");
-				(cell as Gtk.CellRendererPixbuf).visible = (dev.type == "disk");
+				((Gtk.CellRendererPixbuf)cell).sensitive = (dev.type != "disk");
+				((Gtk.CellRendererPixbuf)cell).visible = (dev.type == "disk");
 			}
 		});
 
@@ -237,11 +237,11 @@ class RestoreDeviceBox : Gtk.Box{
 			model.get (iter, 0, out dev, -1);
 
 			if (dev != null){
-				(cell as Gtk.CellRendererText).markup = dev.description_simple_formatted();
-				(cell as Gtk.CellRendererText).sensitive = (dev.type != "disk");
+				((Gtk.CellRendererText)cell).markup = dev.description_simple_formatted();
+				((Gtk.CellRendererText)cell).sensitive = (dev.type != "disk");
 			}
 			else{
-				(cell as Gtk.CellRendererText).markup = _("Keep on Root Device");
+				((Gtk.CellRendererText)cell).markup = _("Keep on Root Device");
 			}
 		});
 		

--- a/src/Gtk/RsyncLogBox.vala
+++ b/src/Gtk/RsyncLogBox.vala
@@ -350,7 +350,7 @@ public class RsyncLogBox : Gtk.Box {
 		combo.set_cell_data_func(cell_text, (cell_layout, cell, model, iter)=>{
 			string val;
 			model.get (iter, 1, out val, -1);
-			(cell as Gtk.CellRendererText).text = val;
+			((Gtk.CellRendererText)cell).text = val;
 		});
 
 		//populate combo

--- a/src/Gtk/UsersBox.vala
+++ b/src/Gtk/UsersBox.vala
@@ -108,7 +108,7 @@ class UsersBox : Gtk.Box{
 		col.set_cell_data_func (cell_text, (cell_layout, cell, model, iter)=>{
 			SystemUser user;
 			model.get(iter, 0, out user);
-			(cell as Gtk.CellRendererText).text = user.name;
+			((Gtk.CellRendererText)cell).text = user.name;
 		});
 
 		// column
@@ -123,7 +123,7 @@ class UsersBox : Gtk.Box{
 		col.set_cell_data_func (cell_text, (cell_layout, cell, model, iter)=>{
 			SystemUser user;
 			model.get(iter, 0, out user);
-			(cell as Gtk.CellRendererText).text = user.home_path;
+			((Gtk.CellRendererText)cell).text = user.home_path;
 		});
 
 		// column -------------------------------------------------


### PR DESCRIPTION
This approach resolves warnings like this:

Access to possible `null'. Perform a check or use an unsafe cast.