### PR TITLE
Don't use the deprecated Gtk.TreeView.rules_hint feature

### DIFF
--- a/src/Gtk/ExcludeAppsBox.vala
+++ b/src/Gtk/ExcludeAppsBox.vala
@@ -70,7 +70,6 @@ class ExcludeAppsBox : Gtk.Box{
 		treeview = new TreeView();
 		treeview.get_selection().mode = SelectionMode.MULTIPLE;
 		treeview.headers_visible = false;
-		treeview.rules_hint = true;
 		treeview.reorderable = true;
 		treeview.set_tooltip_column(2);
 		//treeview.row_activated.connect(treeview_row_activated);

--- a/src/Gtk/ExcludeMessageWindow.vala
+++ b/src/Gtk/ExcludeMessageWindow.vala
@@ -84,7 +84,6 @@ public class ExcludeMessageWindow : Gtk.Dialog{
 		tv_exclude = new TreeView();
 		tv_exclude.get_selection().mode = SelectionMode.MULTIPLE;
 		tv_exclude.headers_visible = false;
-		tv_exclude.set_rules_hint (true);
 
 		//sw_exclude
 		sw_exclude = new ScrolledWindow(null, null);

--- a/src/Gtk/RsyncLogBox.vala
+++ b/src/Gtk/RsyncLogBox.vala
@@ -447,7 +447,6 @@ public class RsyncLogBox : Gtk.Box {
 		treeview.headers_clickable = true;
 		treeview.rubber_banding = true;
 		treeview.has_tooltip = true;
-		treeview.set_rules_hint(true);
 		treeview.show_expanders = false;
 
 		// scrolled

--- a/src/Gtk/SnapshotListBox.vala
+++ b/src/Gtk/SnapshotListBox.vala
@@ -81,7 +81,6 @@ class SnapshotListBox : Gtk.Box{
 		treeview.get_selection().mode = SelectionMode.MULTIPLE;
 		treeview.headers_clickable = true;
 		treeview.has_tooltip = true;
-		treeview.set_rules_hint (true);
 
 		//sw_backups
 		var sw_backups = new ScrolledWindow(null, null);

--- a/src/Gtk/UsersBox.vala
+++ b/src/Gtk/UsersBox.vala
@@ -84,7 +84,6 @@ class UsersBox : Gtk.Box{
 		treeview = new TreeView();
 		treeview.get_selection().mode = SelectionMode.MULTIPLE;
 		treeview.headers_visible = true;
-		treeview.rules_hint = true;
 		treeview.reorderable = false;
 		treeview.set_tooltip_text(_("Click to edit. Drag and drop to re-order."));
 		//treeview.row_activated.connect(treeview_row_activated);


### PR DESCRIPTION
According to the Gtk documentation, the appearance of the ruled tree depends on the selected theme. Hence, if you need “zebra striping”, just use the related theme.