### PR TITLE
Fix the desktop file name + project license in appdata

### DIFF
--- a/debian/timeshift.appdata.xml
+++ b/debian/timeshift.appdata.xml
@@ -3,7 +3,7 @@
 <component type="desktop">
 	<id>timeshift-gtk.desktop</id>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
-	<project_license>GPL-3.0</project_license>
+	<project_license>GPL-2.0-or-later</project_license>
 	<name>Timeshift</name>
 	<summary>System restore utility for Linux</summary>
 	<summary xml:lang="cs">Nástroj pro obnovení systému pro Linux</summary>

--- a/debian/timeshift.appdata.xml
+++ b/debian/timeshift.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 suve <veg@svgames.pl> -->
 <component type="desktop">
-	<id>timeshift.desktop</id>
+	<id>timeshift-gtk.desktop</id>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>GPL-3.0</project_license>
 	<name>Timeshift</name>


### PR DESCRIPTION
The correct name seems to be `timeshift-gtk.desktop`.

/cc @clefebvre @suve