### PR TITLE
build: allow installing default.json to sysconfdir

### DIFF
--- a/files/meson.build
+++ b/files/meson.build
@@ -1,1 +1,5 @@
-install_data(sources : 'timeshift.json', rename : 'default.json', install_dir : '/etc/timeshift')
+install_data(
+  sources: 'timeshift.json',
+  rename: 'default.json',
+  install_dir: get_option('sysconfdir') / 'timeshift',
+)

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@ project(
   'timeshift', 'vala', 'c',
   version: '23.06.2',
   license : 'GPL-2.0-or-later',
+  meson_version: '>= 0.54.0',
   default_options: ['c_std=c99', 'build.c_std=c99'])
 
 dependencies = [

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -285,7 +285,7 @@ public class Main : GLib.Object{
 		this.share_folder = "/usr/share";
 		this.app_conf_path = "/etc/timeshift/timeshift.json";
 		this.app_conf_path_old = "/etc/timeshift.json";
-		this.app_conf_path_default = "/etc/timeshift/default.json";
+		this.app_conf_path_default = GLib.Path.build_path (GLib.Path.DIR_SEPARATOR_S, Constants.SYSCONFDIR, "timeshift", "default.json");
 		//sys_root and sys_home will be initialized by update_partition_list()
 		
 		// check if running locally ------------------------
@@ -3268,6 +3268,10 @@ public class Main : GLib.Object{
 				file_move(app_conf_path_old, app_conf_path);
 			}
 			else if (file_exists(app_conf_path_default)){
+				// /etc/timeshift might not pre-exist when sysconfdir is not /etc
+				if (!dir_exists(file_parent(app_conf_path))){
+					dir_create(file_parent(app_conf_path));
+				}
 				// copy default file
 				file_copy(app_conf_path_default, app_conf_path);
 			}

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -1,3 +1,4 @@
 namespace Constants {
 	public const string VERSION = "@VERSION@";
+	public const string SYSCONFDIR = "@SYSCONFDIR@";
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,10 +2,17 @@ conf_data = configuration_data()
 conf_data.set('GETTEXT_PACKAGE', meson.project_name())
 conf_data.set('VERSION', meson.project_version())
 
+fs = import('fs')
+if (fs.is_absolute(get_option('sysconfdir')))
+  conf_data.set('SYSCONFDIR', get_option('sysconfdir'))
+else
+  conf_data.set('SYSCONFDIR', get_option('prefix') / get_option('sysconfdir'))
+endif
+
 config_header = configure_file(
-    input: 'config.vala.in',
-    output: 'config.vala',
-    configuration: conf_data
+  input: 'config.vala.in',
+  output: 'config.vala',
+  configuration: conf_data
 )
 
 sources_core = files([


### PR DESCRIPTION
Motivation is in commit message:

> In NixOS, packages are installed to their own prefix and
we are not allowed to install this file to /etc.

---

I don't really know how *distros* pass meson flags when building, I assume:

- In 99% case, `--prefix=/usr` is passed and [the docs say](https://mesonbuild.com/Builtin-options.html#universal-options) in this case sysconfdir defaults to `/etc` (absolute path)
- In our case, `--prefix=/nix/store/xxxxxxx-timeshift-23.06.2` is passed, since we don't pass sysconfdir it should default to `etc` (relative path)
- Hopefully no other weird case :sweat: 

I try to [handle these cases with `fs.is_absolute`](https://mesonbuild.com/Fs-module.html#is_absolute), which will require meson 0.54.0, which should be in debian 11 or debian 10 backports. Hopefully I am not breaking things.

I assume, testing should be simple as `rm -rf /etc/timeshift`, build and start the app and see if the app starts.