### PR TITLE
treewide: use /usr/bin/env bash for shebang

### DIFF
--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -86,7 +86,7 @@ namespace TeeJee.ProcessHelper{
 		
 		if (run_as_admin){
 			
-			var script_admin = "#!/bin/bash\n";
+			var script_admin = "#!/usr/bin/env bash\n";
 			script_admin += "pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY";
 			script_admin += " '%s'".printf(escape_single_quote(sh_file));
 			
@@ -195,7 +195,7 @@ namespace TeeJee.ProcessHelper{
 		 * Returns the script file path */
 
 		var script = new StringBuilder();
-		script.append ("#!/bin/bash\n");
+		script.append ("#!/usr/bin/env bash\n");
 		script.append ("\n");
 		if (force_locale){
 			script.append("LANG=C\n");

--- a/src/timeshift-launcher
+++ b/src/timeshift-launcher
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 app_command='timeshift-gtk'
 


### PR DESCRIPTION
The motivation is in commit message:

> NixOS does not have /bin/bash but we do have /usr/bin/env for POSIX compliance.



---

I expect /usr/bin/env to exist and work for all distros and [`/usr/bin/env` is widely used in GNOME](https://github.com/search?q=org%3AGNOME+%23%21%2Fusr%2Fbin%2Fenv&type=code)


... though I actually believe NixOS is the evil here, searching "/bin/bash nixos" on GitHub [gives me 4k issues](https://github.com/search?q=%2Fbin%2Fbash+nixos&type=issues) :sweat_smile: The situation is actually not "that" bad, [patching shebang is semi-automatic in NixOS](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20patchShebangs&type=code), unfortunately here are 2 cases in `src/Utility/TeeJee.Process.vala` which our tooling cannot handle (automatically). 

[Related discussion in NixOS discourse](https://discourse.nixos.org/t/add-bin-bash-to-avoid-unnecessary-pain/5673)