### PR TITLE
docs/man/meson.build: Use -N for help2man to avoid texinfo section

### DIFF
--- a/docs/man/meson.build
+++ b/docs/man/meson.build
@@ -1,8 +1,8 @@
 help2man = find_program('help2man')
 
 mans = [
-  ['timeshift', [help2man, '--output=@OUTPUT@', timeshift]],
-  ['timeshift-gtk', [help2man, '--output=@OUTPUT@', timeshift_gtk]],
+  ['timeshift', [help2man, '-N', '--output=@OUTPUT@', timeshift]],
+  ['timeshift-gtk', [help2man, '-N', '--output=@OUTPUT@', timeshift_gtk]],
 ]
 
 foreach man: mans


### PR DESCRIPTION
If -N option is not added, the following section will be appended to the generated man pages:

```
SEE ALSO
       The  full documentation for Timeshift is maintained as a Texinfo manual.  If the info and Timeshift programs are properly installed
       at your site, the command

              info Timeshift

       should give you access to the complete manual.
```

This is not desired, thus add the -N option to the help2man invocation.