### PR TITLE
Add the installation/removal instructions for the timeshift Arch package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ sudo dnf update
 sudo dnf install timeshift
 ```
 
+#### Arch
+
+```sh
+sudo pacman -S timeshift
+```
+
 ## Removal
 
 Run the following command in a terminal window:  
@@ -177,6 +183,10 @@ Run the following command in a terminal window:
 or
 
     sudo dnf remove timeshift
+
+or
+
+    sudo pacman -R timeshift
 
 depending in your package management system.
 


### PR DESCRIPTION
Hi!

Timeshift is now [packaged in the official Arch [extra] repository](https://archlinux.org/packages/extra/x86_64/timeshift/)!
This PR aims to add the installation/removal instructions for the timeshift Arch package in the README alongside the Debian/Ubuntu's and Fedora's ones. :smiley: 