### PR TITLE
docs/development.md: fix meson setup command

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -44,7 +44,7 @@ cd timeshift
 ### Step 3. Build Timeshift
 
 ```bash
-meson setup -C build
+meson setup build
 meson compile -C build 
 ``` 
 


### PR DESCRIPTION
`meson setup` command accepts the build folder name directly.