### PR TITLE
Relocated 'delete' to a safer position.

### DIFF
--- a/src/Gtk/SnapshotListBox.vala
+++ b/src/Gtk/SnapshotListBox.vala
@@ -316,23 +316,9 @@ class SnapshotListBox : Gtk.Box{
 
 		// menu_file
 		menu_snapshots = new Gtk.Menu();
-
-		// mi_remove
-		var item = new ImageMenuItem.with_label(_("Delete"));
-		item.image = IconManager.lookup_image("edit-delete", 16);
-		item.activate.connect(()=> { delete_selected(); });
-		menu_snapshots.append(item);
-		mi_remove = item;
-		
-		// mi_mark
-		item = new ImageMenuItem.with_label(_("Mark/Unmark for Deletion"));
-		item.image = IconManager.lookup_image("edit-delete", 16);
-		item.activate.connect(()=> { mark_selected(); });
-		menu_snapshots.append(item);
-		mi_mark = item;
 		
 		// mi_browse
-		item = new ImageMenuItem.with_label(_("Browse Files"));
+		var item = new ImageMenuItem.with_label(_("Browse Files"));
         item.image = IconManager.lookup_image(IconManager.GENERIC_ICON_DIRECTORY, 16);
 		item.activate.connect(()=> { browse_selected(); });
 		menu_snapshots.append(item);
@@ -351,6 +337,20 @@ class SnapshotListBox : Gtk.Box{
 		item.activate.connect(()=> { view_snapshot_log(true); });
 		menu_snapshots.append(item);
 		mi_view_log_restore = item;
+
+		// mi_remove
+		item = new ImageMenuItem.with_label(_("Delete"));
+		item.image = IconManager.lookup_image("edit-delete", 16);
+		item.activate.connect(()=> { delete_selected(); });
+		menu_snapshots.append(item);
+		mi_remove = item;
+		
+		// mi_mark
+		item = new ImageMenuItem.with_label(_("Mark/Unmark for Deletion"));
+		item.image = IconManager.lookup_image("edit-delete", 16);
+		item.activate.connect(()=> { mark_selected(); });
+		menu_snapshots.append(item);
+		mi_mark = item;
 		
 		menu_snapshots.show_all();
 


### PR DESCRIPTION
In current version, when right clicking a snapshot, 'delete' is positioned at the top of the list. In most situations that puts it only a few pixels away from the mouse's current position which makes it very easy to accidentally click. This is the simplest fix, just moving delete to the bottom of the list instead of the top.