### PR TITLE
Remove dependencies to external binarys

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -206,7 +206,7 @@ public class Main : GLib.Object{
 		}
 
 		check_and_remove_timeshift_btrfs();
-		
+
 		// init log ------------------
 
 		try {
@@ -4375,17 +4375,19 @@ public class Main : GLib.Object{
 			
 							string cmd = "umount '%s'".printf(escape_single_quote(mdir2));
 							int retval = exec_sync(cmd);
-							
-							string cmd2 = "rmdir '%s'".printf(escape_single_quote(mdir2));
-							int retval2 = exec_sync(cmd2);
-							
-							if (retval2 != 0){
+
+							if (retval != 0){
 								log_debug("E: Failed to unmount");
 								log_debug("Ret=%d".printf(retval));
 								//ignore
 							}
 							else{
 								log_debug("Unmounted successfully");
+							}
+
+							// delete directory
+							if(!dir_empty_delete(mdir2)) {
+								log_debug("E: Failed to delete %s".printf(mdir2));
 							}
 						}
 					}

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3922,12 +3922,7 @@ public class Main : GLib.Object{
 				ret_val = exec_script_sync(cmd, out std_out, out std_err);
 				if (ret_val == 0){
 					required_space = long.parse(std_out.replace(",","").strip());
-
-					cmd = "wc -l '%s'".printf(escape_single_quote(file_log));
-					ret_val = exec_script_sync(cmd, out std_out, out std_err);
-					if (ret_val == 0){
-						file_count = long.parse(std_out.split(" ")[0].strip());
-					}
+					file_count = file_line_count(file_log) ?? 0;
 					
 					thr_success = true;
 				}

--- a/src/Core/SnapshotRepo.vala
+++ b/src/Core/SnapshotRepo.vala
@@ -897,11 +897,6 @@ public class SnapshotRepo : GLib.Object{
 	// symlinks ----------------------------------------
 	
 	public void create_symlinks(){
-		string cmd = "";
-		string std_out;
-		string std_err;
-		int ret_val;
-
 		cleanup_symlink_dir("boot");
 		cleanup_symlink_dir("hourly");
 		cleanup_symlink_dir("daily");
@@ -909,21 +904,19 @@ public class SnapshotRepo : GLib.Object{
 		cleanup_symlink_dir("monthly");
 		cleanup_symlink_dir("ondemand");
 
-		string path;
 
-		foreach(var bak in snapshots){
-			foreach(string tag in bak.tags){
-				
-				path = "%s-%s".printf(snapshots_path, tag);
-				cmd = "ln --symbolic \"../snapshots/%s\" -t \"%s\"".printf(bak.name, path);
-
-				if (LOG_COMMANDS) { log_debug(cmd); }
-
-				ret_val = exec_sync(cmd, out std_out, out std_err);
-				if (ret_val != 0){
-					log_error (std_err);
-					log_error(_("Failed to create symlinks") + ": snapshots-%s".printf(tag));
-					return;
+		foreach(Snapshot bak in snapshots){
+			foreach(string tag in bak.tags) {
+				string linkTarget = "%s-%s/%s".printf(snapshots_path, tag, bak.name);
+				string linkValue = "../snapshots/" + bak.name;
+				try {
+					File f = File.new_for_path(linkTarget);
+					if (!f.make_symbolic_link(linkValue)) {
+						log_error(_("Failed to create symlinks") + ": %s".printf(linkTarget));
+					}
+				} catch(Error e) {
+					log_debug(e.message);
+					log_error(_("Failed to create symlinks") + ": %s".printf(linkTarget));
 				}
 			}
 		}

--- a/src/Utility/AppLock.vala
+++ b/src/Utility/AppLock.vala
@@ -45,7 +45,7 @@ public class AppLock : GLib.Object {
 				lock_message = txt.split(";")[1].strip();
 				long pid = long.parse(process_id);
 
-				if (process_is_running(pid)){
+				if (get_process_exe_name(pid).contains("timeshift")){
 					log_msg(_("Another instance of this application is running")
 						+ " (PID=%ld)".printf(pid));
 					return false;

--- a/src/Utility/AsyncTask.vala
+++ b/src/Utility/AsyncTask.vala
@@ -394,9 +394,7 @@ public abstract class AsyncTask : GLib.Object{
 		if (status == AppStatus.RUNNING) {
 			process_set_priority (child_pid, prio);
 
-			Pid sub_child_pid;
-			foreach (long pid in get_process_children (child_pid)) {
-				sub_child_pid = (Pid) pid;
+			foreach (Pid sub_child_pid in get_process_children (child_pid)) {
 				process_set_priority (sub_child_pid, prio);
 			}
 		}

--- a/src/Utility/DeleteFileTask.vala
+++ b/src/Utility/DeleteFileTask.vala
@@ -69,7 +69,7 @@ public class DeleteFileTask : AsyncTask{
 			log_error (e.message);
 		}
 	}
-	
+
 	public void prepare() {
 		string script_text = build_script();
 		log_debug(script_text);
@@ -113,13 +113,10 @@ public class DeleteFileTask : AsyncTask{
 			cmd += " '%s/'".printf(escape_single_quote(dest_path));
 		}
 		else{
-			cmd += "rm";
+			cmd += "rm -rf";
 
 			if (verbose){
-				cmd += " -rfv";
-			}
-			else{
-				cmd += " -rf";
+				cmd += "v";
 			}
 
 			cmd += " '%s'".printf(escape_single_quote(dest_path));

--- a/src/Utility/LinuxDistro.vala
+++ b/src/Utility/LinuxDistro.vala
@@ -152,50 +152,6 @@ public class LinuxDistro : GLib.Object{
 		return info;
 	}
 
-	public static string get_running_desktop_name(){
-
-		/* Return the names of the current Desktop environment */
-
-		int pid = -1;
-
-		pid = get_pid_by_name("cinnamon");
-		if (pid > 0){
-			return "Cinnamon";
-		}
-
-		pid = get_pid_by_name("xfdesktop");
-		if (pid > 0){
-			return "Xfce";
-		}
-
-		pid = get_pid_by_name("lxsession");
-		if (pid > 0){
-			return "LXDE";
-		}
-
-		pid = get_pid_by_name("gnome-shell");
-		if (pid > 0){
-			return "Gnome";
-		}
-
-		pid = get_pid_by_name("wingpanel");
-		if (pid > 0){
-			return "Elementary";
-		}
-
-		pid = get_pid_by_name("unity-panel-service");
-		if (pid > 0){
-			return "Unity";
-		}
-
-		pid = get_pid_by_name("plasma-desktop");
-		if (pid > 0){
-			return "KDE";
-		}
-
-		return "Unknown";
-	}
-
 	public string dist_type {
 		
 		owned get{

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -289,7 +289,7 @@ public class RsyncTask : AsyncTask{
 		log_debug("log_file = %s".printf(log_file));
 
 		prg_count = 0;
-		prg_count_total = file_line_count(log_file);
+		prg_count_total = file_line_count(log_file) ?? 0;
 
 		try {
 			string line;

--- a/src/Utility/TeeJee.FileSystem.vala
+++ b/src/Utility/TeeJee.FileSystem.vala
@@ -88,12 +88,28 @@ namespace TeeJee.FileSystem{
 	    }
 	}
 
-	public int64 file_line_count (string file_path){
-		/* Count number of lines in text file */
-		string cmd = "wc -l '%s'".printf(escape_single_quote(file_path));
-		string std_out, std_err;
-		exec_sync(cmd, out std_out, out std_err);
-		return long.parse(std_out.split("\t")[0]);
+	public int64? file_line_count (string file_path){
+		/* Count number of lines in text file returns null on error */
+
+		try {
+			long line_nums = 0;
+			char symbol;
+
+			File file = File.new_for_path(file_path);
+			FileInputStream inStream = file.read();
+			BufferedInputStream bis = new BufferedInputStream.sized(inStream,  (size_t) (1 * MiB));
+			while((symbol = (char) bis.read_byte()) != -1) {
+				if(symbol == '\n') {
+					line_nums ++;
+				}
+			}
+			bis.close();
+			return line_nums;
+		} catch(Error e) {
+			log_error (e.message);
+			log_error(_("Failed to read file") + ": %s".printf(file_path));
+		}
+		return null;
 	}
 
 	public string? file_read (string file_path){

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -272,27 +272,14 @@ namespace TeeJee.ProcessHelper{
 		}
 	}
 
-
-	// dep: ps TODO: Rewrite using /proc
-	public bool process_is_running(long pid){
-
-		/* Checks if given process is running */
-
-		string cmd = "";
-		string std_out;
-		string std_err;
-		int ret_val;
-
-		try{
-			cmd = "ps --pid %ld".printf(pid);
-			Process.spawn_command_line_sync(cmd, out std_out, out std_err, out ret_val);
-		}
-		catch (Error e) {
-			log_error (e.message);
-			return false;
-		}
-
-		return (ret_val == 0);
+	// return the name of the executeable of a given pid or self if pid is <= 0
+	// returns an empty string on error or if the pid could not be found
+	public string get_process_exe_name(long pid = -1){
+		string pidStr = (pid <= 0 ? "self" : pid.to_string());
+		string path = "/proc/%s/exe".printf(pidStr);
+		char[] buf = new char[4096];
+		Posix.readlink(path, buf);
+		return GLib.Path.get_basename((string) buf);
 	}
 
 	// dep: ps TODO: Rewrite using /proc

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -312,37 +312,34 @@ namespace TeeJee.ProcessHelper{
 	
 	public void process_quit(Pid process_pid, bool killChildren = true){
 
-		/* Kills specified process and its children (optional).
+		/* Terminates specified process and its children (optional).
 		 * Sends signal SIGTERM to the process to allow it to quit gracefully.
 		 * */
 
-		int[] child_pids = get_process_children (process_pid);
-		Posix.kill (process_pid, Posix.Signal.TERM);
-
-		if (killChildren){
-			Pid childPid;
-			foreach (long pid in child_pids){
-				childPid = (Pid) pid;
-				Posix.kill (childPid, Posix.Signal.TERM);
-			}
-		}
+		process_send_signal(process_pid, Posix.Signal.TERM, killChildren);
 	}
 	
-	public void process_kill(Pid process_pid, bool killChildren = true){
+	public void process_kill(Pid process_pid, bool killChildren = true) {
 
 		/* Kills specified process and its children (optional).
 		 * Sends signal SIGKILL to the process to kill it forcefully.
 		 * It is recommended to use the function process_quit() instead.
 		 * */
 		
-		int[] child_pids = get_process_children (process_pid);
-		Posix.kill (process_pid, Posix.Signal.KILL);
+		process_send_signal(process_pid, Posix.Signal.KILL, killChildren);
+	}
 
-		if (killChildren){
-			Pid childPid;
+	public void process_send_signal(Pid process_pid, Posix.Signal sig, bool children = true) {
+
+		/* Sends a signal to a process and its children (optional). */
+		
+		// get the childs before sending the signal, as the childs might not be accessible afterwards
+		int[] child_pids = get_process_children (process_pid);
+		Posix.kill (process_pid, sig);
+		 
+		 if (children){
 			foreach (long pid in child_pids){
-				childPid = (Pid) pid;
-				Posix.kill (childPid, Posix.Signal.KILL);
+				Posix.kill ((Pid) pid, sig);
 			}
 		}
 	}

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -272,23 +272,6 @@ namespace TeeJee.ProcessHelper{
 		}
 	}
 
-	// dep: pidof, TODO: Rewrite using /proc
-	public int get_pid_by_name (string name){
-
-		/* Get the process ID for a process with given name */
-
-		string std_out, std_err;
-		exec_sync("pidof \"%s\"".printf(name), out std_out, out std_err);
-		
-		if (std_out != null){
-			string[] arr = std_out.split ("\n");
-			if (arr.length > 0){
-				return int.parse (arr[0]);
-			}
-		}
-
-		return -1;
-	}
 
 	// dep: ps TODO: Rewrite using /proc
 	public bool process_is_running(long pid){


### PR DESCRIPTION
I have started to remove some dependencies to external binarys, as easy alternatives are available.

This makes those actions of timeshift faster and more efficient, as fewer syscalls are required to archive the same result. It also allows timeshift to have more detailed knowledge about the errors that might happen.

in future pull requests i would like to remove more dependencies to simple programms, such as cp, touch, mount, umount, chown, chmod ...