### PR TITLE
Btrfs: support default subvolid!=0

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3760,7 +3760,7 @@ public class Main : GLib.Object{
 						return false;
 					}
 					else{
-						Device.mount(dev_unlocked.uuid, mnt_btrfs, "", true);
+						Device.mount(dev_unlocked.uuid, mnt_btrfs, "subvolid=0", true);
 					}
 				}
 				else{
@@ -3768,7 +3768,7 @@ public class Main : GLib.Object{
 				}
 			}
 			else{
-				Device.mount(dev.uuid, mnt_btrfs, "", true);
+				Device.mount(dev.uuid, mnt_btrfs, "subvolid=0", true);
 			}
 		}
 

--- a/src/Core/SnapshotRepo.vala
+++ b/src/Core/SnapshotRepo.vala
@@ -260,7 +260,11 @@ public class SnapshotRepo : GLib.Object{
 		}
 
 		// mount
-		bool ok = Device.mount(dev.uuid, path_to_mount, ""); // TODO: check if already mounted
+		var mount_options = "";
+		if (btrfs_mode){
+			mount_options = "subvolid=0";
+		}
+		bool ok = Device.mount(dev.uuid, path_to_mount, mount_options); // TODO: check if already mounted
 		
 		if (ok){
 			return path_to_mount;

--- a/src/Utility/Device.vala
+++ b/src/Utility/Device.vala
@@ -1627,13 +1627,13 @@ public class Device : GLib.Object{
 		unmount(mount_point);
 
 		// mount the device -------------------
-		
 		if (mount_options.length > 0){
 			cmd = "mount -o %s \"%s\" \"%s\"".printf(mount_options, device, mount_point);
 		}
 		else{
 			cmd = "mount \"%s\" \"%s\"".printf(device, mount_point);
 		}
+		log_debug("mount command: %s".printf(cmd));
 
 		ret_val = exec_sync(cmd, out std_out, out std_err);
 


### PR DESCRIPTION
Hi,

This commit makes timeshift mount the btrfs filesystem with `-o subvolid=0` so that it supports setups where the default subvolid is not 0.

Cheers,
Pierre