### PR TITLE
Fix timeshift.appdata.xml

### DIFF
--- a/debian/timeshift.appdata.xml
+++ b/debian/timeshift.appdata.xml
@@ -10,33 +10,29 @@
 	<summary xml:lang="hr">Alat obnove sustava za Linux</summary>
 
 	<description>
-		<p>
+		<p xml:lang="en">
 			Timeshift protects your system by taking incremental snapshots of the file system at regular intervals.
 			These snapshots can be restored at a later date to undo all changes to the system. 
 		</p>
-		<p>
+		<p xml:lang="en">
 			Timeshift is designed to protect system files and settings.
 			It is NOT a backup tool and is not meant to protect user data.
 			Entire contents of users' home directories are excluded by default.
 		</p>
-	</description>
-	<description xml:lang="cs">
-		<p>
+		<p xml:lang="cs">
 			Timeshift chrání systém pořizováním přírůstkových zachycených stavů souborového systému v pravidelných intervalech.
 			Tyto zachycené stavy je možné později obnovit a vzít tak zpět veškeré změny v systému. 
 		</p>
-		<p>
+		<p xml:lang="cs">
 			Timeshift je navržen tak, aby chránil systémové soubory a nastavení.
 			NEJEDNÁ se o zálohovací nástroj a není určen k ochraně dat uživatelů.
 			Veškerý obsah domovských složek uživatelů je ve výchozím stavu vynecháván.
 		</p>
-	</description>
-	<description xml:lang="hr">
-		<p>
+		<p xml:lang="hr">
 			Timeshift štiti vaš sustav stvaranjem pojedinačnih snimaka datotečnog sustava u redovitim vremenskim razmacima.
 			Te snimke sustava kasnije se mogu obnoviti kako bi se poništile sve promjene načinjene u sustavu. 
 		</p>
-		<p>
+		<p xml:lang="hr">
 			Timeshift je dizajniran kako bi zaštitio vaše datoteke i postavke sustava.
 			Timeshift nije alat za sigurnosno kopiranje i namjena mu nije zaštita korisničkih podataka.
 			Sav sadržaj osobne mape korisnika po zadanome je izuzet.


### PR DESCRIPTION
Moved the xml:tag inside the `<p/>` elements instead of the surrounding `<description/>` elements and made multiple description tags into one.

(The [specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description) says: In MetaInfo files, this tag (`<description/>`) should be translated by-paragraph. For enumerations, items are translated individually as well, and not the whole enumeration block. This means that in a translated file, only `<p/>` and `<li/>` elements may carry an xml:lang property.)