### PR TITLE
BTRFS custom hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ You can selectively include items for backup from the ***Settings*** window. Sel
   - **@** and **@home** subvolumes may be on same or different BTRFS volumes
   - **@** may be on BTRFS volume and **/home** may be mounted on non-BTRFS partition
   - If swap files are used they should not be located in **@** or **@home** and could instead be stored in their own subvolume, eg **@swap**
+  - Separate partitions (e.g. `/boot`) can be handled via custom created hooks (placed in `/etc/timeshift/backup-hooks.d/` and `/etc/timeshift/restore-hooks.d/`) 
   - Other layouts are not supported
   - Make sure, that you have selected subvolume *@* or */@* for root. You can check that executing script below, and if output is *OK*, then everything is alright.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can selectively include items for backup from the ***Settings*** window. Sel
   - **@** and **@home** subvolumes may be on same or different BTRFS volumes
   - **@** may be on BTRFS volume and **/home** may be mounted on non-BTRFS partition
   - If swap files are used they should not be located in **@** or **@home** and could instead be stored in their own subvolume, eg **@swap**
-  - Separate partitions (e.g. `/boot`) can be handled via custom created hooks (placed in `/etc/timeshift/backup-hooks.d/` and `/etc/timeshift/restore-hooks.d/`) 
+  - Separate partitions (e.g. `/boot`) can be handled via custom created hooks (placed in `/etc/timeshift/backup-hooks.d/` and `/etc/timeshift/restore-hooks.d/`). Script naming must match `run-parts` [requirements](https://manpages.ubuntu.com/manpages/noble/man8/run-parts.8.html). Current snapshot path is exported as `TS_SNAPSHOT_PATH`.
   - Other layouts are not supported
   - Make sure, that you have selected subvolume *@* or */@* for root. You can check that executing script below, and if output is *OK*, then everything is alright.
 

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Homepage: https://github.com/linuxmint/timeshift
 
 Package: timeshift
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, rsync, btrfs-progs | btrfs-tools
+Depends: ${shlibs:Depends}, ${misc:Depends}, rsync, debianutils, btrfs-progs | btrfs-tools
 Replaces: timeshift-btrfs
 Description: System restore utility
  Timeshift is a system restore utility which takes snapshots

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3045,9 +3045,8 @@ public class Main : GLib.Object{
 		// Perform any post-restore actions
 		log_debug("Running post-restore tasks...");
 
-		string sh = "if [ -d \"/etc/timeshift/restore-hooks.d\" ]; then \n";
-		sh += "  run-parts --verbose /etc/timeshift/restore-hooks.d \n";
-		sh += "fi \n";
+		string sh = "test -d \"/etc/timeshift/restore-hooks.d\" &&"
+		"  run-parts --verbose /etc/timeshift/restore-hooks.d";
 
 		exec_script_sync(sh, null, null, false, false, false, true);
 		log_debug("Finished running post-restore tasks...");

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -352,7 +352,7 @@ public class Main : GLib.Object{
 
 		log_debug("Main: check_dependencies()");
 		
-		string[] dependencies = { "rsync","/sbin/blkid","df","mount","umount","fuser","crontab","cp","rm","touch","ln","sync","which"}; //"shutdown","chroot",
+		string[] dependencies = { "rsync","/sbin/blkid","df","mount","umount","fuser","crontab","cp","rm","touch","ln","sync","which", "run-parts"}; //"shutdown","chroot",
 
 		string path;
 		foreach(string cmd_tool in dependencies){

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3046,7 +3046,7 @@ public class Main : GLib.Object{
 		// Perform any post-restore actions
 		log_debug("Running post-restore tasks...");
 
-		string sh += "if [ -d \"/etc/timeshift/restore-hooks.d\" ]; then \n";
+		string sh = "if [ -d \"/etc/timeshift/restore-hooks.d\" ]; then \n";
 		sh += "  run-parts --verbose /etc/timeshift/restore-hooks.d \n";
 		sh += "fi \n";
 

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1696,7 +1696,7 @@ public class Main : GLib.Object{
 		// Perform any post-backup actions
 		log_debug("Running post-backup tasks...");
 		
-		string sh = "test -d \"/etc/timeshift/backup-hooks.d\" &&"
+		string sh = "test -d \"/etc/timeshift/backup-hooks.d\" &&" +
 		"  run-parts --verbose /etc/timeshift/backup-hooks.d";
 		exec_script_sync(sh, null, null, false, false, false, true);
 
@@ -3045,7 +3045,7 @@ public class Main : GLib.Object{
 		// Perform any post-restore actions
 		log_debug("Running post-restore tasks...");
 
-		string sh = "test -d \"/etc/timeshift/restore-hooks.d\" &&"
+		string sh = "test -d \"/etc/timeshift/restore-hooks.d\" &&" +
 		"  run-parts --verbose /etc/timeshift/restore-hooks.d";
 
 		exec_script_sync(sh, null, null, false, false, false, true);

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1696,9 +1696,8 @@ public class Main : GLib.Object{
 		// Perform any post-backup actions
 		log_debug("Running post-backup tasks...");
 		
-		string sh = "if [ -d \"/etc/timeshift/backup-hooks.d\" ]; then \n";
-		sh += "  run-parts --verbose /etc/timeshift/backup-hooks.d \n";
-		sh += "fi \n";
+		string sh = "test -d \"/etc/timeshift/backup-hooks.d\" &&"
+		"  run-parts --verbose /etc/timeshift/backup-hooks.d";
 		exec_script_sync(sh, null, null, false, false, false, true);
 
 		log_debug("Finished running post-backup tasks...");

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3046,9 +3046,11 @@ public class Main : GLib.Object{
 		log_debug("Running post-restore tasks...");
 
 		string sh = "test -d \"/etc/timeshift/restore-hooks.d\" &&" +
-		"  run-parts --verbose /etc/timeshift/restore-hooks.d";
+		" export TS_SNAPSHOT_PATH=\"" + snapshot_to_restore.path + "\" &&" + 
+		" run-parts --verbose /etc/timeshift/restore-hooks.d";
 
 		exec_script_sync(sh, null, null, false, false, false, true);
+
 		log_debug("Finished running post-restore tasks...");
 		
 		if (restore_current_system){

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1693,6 +1693,16 @@ public class Main : GLib.Object{
 
 		set_tags(snapshot); // set_tags() will update the control file
 		
+		// Perform any post-backup actions
+		log_debug("Running post-backup tasks...");
+		
+		string sh = "if [ -d \"/etc/timeshift/backup-hooks.d\" ]; then \n";
+		sh += "  run-parts --verbose /etc/timeshift/backup-hooks.d \n";
+		sh += "fi \n";
+		exec_script_sync(sh, null, null, false, false, false, true);
+
+		log_debug("Finished running post-backup tasks...");
+
 		return snapshot;
 	}
 
@@ -3032,6 +3042,16 @@ public class Main : GLib.Object{
 
 		log_msg(_("Restore completed"));
 		thr_success = true;
+
+		// Perform any post-restore actions
+		log_debug("Running post-restore tasks...");
+
+		string sh += "if [ -d \"/etc/timeshift/restore-hooks.d\" ]; then \n";
+		sh += "  run-parts --verbose /etc/timeshift/restore-hooks.d \n";
+		sh += "fi \n";
+
+		exec_script_sync(sh, null, null, false, false, false, true);
+		log_debug("Finished running post-restore tasks...");
 		
 		if (restore_current_system){
 			log_msg(_("Snapshot will become active after system is rebooted."));

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1697,7 +1697,8 @@ public class Main : GLib.Object{
 		log_debug("Running post-backup tasks...");
 		
 		string sh = "test -d \"/etc/timeshift/backup-hooks.d\" &&" +
-		"  run-parts --verbose /etc/timeshift/backup-hooks.d";
+		" export TS_SNAPSHOT_PATH=\"" + snapshot_path + "\" &&" + 
+		" run-parts --verbose /etc/timeshift/backup-hooks.d";
 		exec_script_sync(sh, null, null, false, false, false, true);
 
 		log_debug("Finished running post-backup tasks...");


### PR DESCRIPTION
Allows creation a custom hooks for btrfs filesystem, 

Fixes #365 - allows using timeshift when, e.g., `/boot` is on a separate partition or other individual setup that requires tunning.

Tested on Ubuntu 24.04. 

## Locations:
- backup scripts `/etc/timeshift/backup-hooks.d/*` 
- restore scripts `/etc/timeshift/restore-hooks.d/*`

## Scripts filename [requirements](https://manpages.ubuntu.com/manpages/jammy/man8/run-parts.8.html):
> the  names  must consist  entirely of ASCII upper- and lower-case letters, ASCII digits, ASCII underscores, and ASCII minus-hyphens.

Above means e.g. `restore.sh` is invalid filename as it contains `.` symbol (which mean file will be ignored).


There is `export TS_SNAPSHOT_PATH` which equals current snapshot path (for use in both Restore & Backup hooks).

