### PR TITLE
Update function restore_current_system() to check that dst_root is not null

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1892,7 +1892,7 @@ public class Main : GLib.Object{
 	public bool restore_current_system{
 		get {
 			if ((sys_root != null) &&
-				((dst_root.device == sys_root.device) || (dst_root.uuid == sys_root.uuid))){
+				((dst_root != null && dst_root.device == sys_root.device) || (dst_root != null && dst_root.uuid == sys_root.uuid))){
 					
 				return true;
 			}


### PR DESCRIPTION
Fixes #278:

```
Thread 1 "timeshift" received signal SIGSEGV, Segmentation fault.
0x00005555555a2fb9 in main_get_restore_current_system (self=0x555555670010) at ../src/Core/Main.vala:1895
1895					((dst_root.device == sys_root.device) || (dst_root.uuid == sys_root.uuid))){
```