### PR TITLE
AppStream metadata fixes

### DIFF
--- a/debian/com.linuxmint.timeshift.metainfo.xml
+++ b/debian/com.linuxmint.timeshift.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2017 suve <veg@svgames.pl> -->
 <component type="desktop">
-	<id>timeshift-gtk.desktop</id>
+	<id>com.linuxmint.timeshift</id>
 	<metadata_license>CC-BY-SA-3.0</metadata_license>
 	<project_license>GPL-2.0-or-later</project_license>
 	<name>Timeshift</name>

--- a/debian/timeshift.appdata.xml
+++ b/debian/timeshift.appdata.xml
@@ -10,11 +10,11 @@
 	<summary xml:lang="hr">Alat obnove sustava za Linux</summary>
 
 	<description>
-		<p xml:lang="en">
+		<p>
 			Timeshift protects your system by taking incremental snapshots of the file system at regular intervals.
 			These snapshots can be restored at a later date to undo all changes to the system. 
 		</p>
-		<p xml:lang="en">
+		<p>
 			Timeshift is designed to protect system files and settings.
 			It is NOT a backup tool and is not meant to protect user data.
 			Entire contents of users' home directories are excluded by default.

--- a/debian/timeshift.appdata.xml
+++ b/debian/timeshift.appdata.xml
@@ -14,23 +14,23 @@
 			Timeshift protects your system by taking incremental snapshots of the file system at regular intervals.
 			These snapshots can be restored at a later date to undo all changes to the system. 
 		</p>
+		<p xml:lang="cs">
+			Timeshift chrání systém pořizováním přírůstkových zachycených stavů souborového systému v pravidelných intervalech.
+			Tyto zachycené stavy je možné později obnovit a vzít tak zpět veškeré změny v systému.
+		</p>
+		<p xml:lang="hr">
+			Timeshift štiti vaš sustav stvaranjem pojedinačnih snimaka datotečnog sustava u redovitim vremenskim razmacima.
+			Te snimke sustava kasnije se mogu obnoviti kako bi se poništile sve promjene načinjene u sustavu.
+		</p>
 		<p>
 			Timeshift is designed to protect system files and settings.
 			It is NOT a backup tool and is not meant to protect user data.
 			Entire contents of users' home directories are excluded by default.
 		</p>
 		<p xml:lang="cs">
-			Timeshift chrání systém pořizováním přírůstkových zachycených stavů souborového systému v pravidelných intervalech.
-			Tyto zachycené stavy je možné později obnovit a vzít tak zpět veškeré změny v systému. 
-		</p>
-		<p xml:lang="cs">
 			Timeshift je navržen tak, aby chránil systémové soubory a nastavení.
 			NEJEDNÁ se o zálohovací nástroj a není určen k ochraně dat uživatelů.
 			Veškerý obsah domovských složek uživatelů je ve výchozím stavu vynecháván.
-		</p>
-		<p xml:lang="hr">
-			Timeshift štiti vaš sustav stvaranjem pojedinačnih snimaka datotečnog sustava u redovitim vremenskim razmacima.
-			Te snimke sustava kasnije se mogu obnoviti kako bi se poništile sve promjene načinjene u sustavu. 
 		</p>
 		<p xml:lang="hr">
 			Timeshift je dizajniran kako bi zaštitio vaše datoteke i postavke sustava.

--- a/debian/timeshift.appdata.xml
+++ b/debian/timeshift.appdata.xml
@@ -39,6 +39,7 @@
 		</p>
 	</description>
 
+	<launchable type="desktop-id">timeshift-gtk.desktop</launchable>
 
 	<screenshots>
 		<screenshot type="default">

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,6 @@ if enable_man
 endif
 
 install_data(
-  sources: 'debian/timeshift.appdata.xml',
+  sources: 'debian/com.linuxmint.timeshift.metainfo.xml',
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )


### PR DESCRIPTION
This PR makes the following changes to the AppStream metadata file:

1. Removes the `xml:lang="en"` attribute from description paragraph. While the AppStream specification doesn't really say anything about this[^0], it seems that `appstreamcli` treats translated descriptions as overrides, and expects the existence of a default description without a language marker.

2. Adds the `<launchable>` tag to inform consumers how to launch the application[^1].

3. Changes the ID to `com.linuxmint.timeshift` (and renames the file accordingly), as AppStream IDs are expected to follow a reverse-DNS `{tld}.{vendor}.{product}` scheme[^2].

[^0]: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description
[^1]: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
[^2]: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic