### PR TITLE
add "timeshift" to the tempdir names

### DIFF
--- a/src/AppConsole.vala
+++ b/src/AppConsole.vala
@@ -76,7 +76,7 @@ public class AppConsole : GLib.Object {
 		}
 
 		LOG_ENABLE = false;
-		init_tmp(AppShortName);
+		init_tmp();
 		LOG_ENABLE = true;
 		
 		check_if_admin();

--- a/src/AppGtk.vala
+++ b/src/AppGtk.vala
@@ -70,7 +70,7 @@ public class AppGtk : GLib.Object {
 
 		GTK_INITIALIZED = true;
 
-		init_tmp(AppShortName);
+		init_tmp();
 
 		check_if_admin();
 

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -37,20 +37,19 @@ namespace TeeJee.ProcessHelper{
     public static void init_tmp(string subdir_name){
 		string std_out, std_err;
 
-		TEMP_DIR = Environment.get_tmp_dir() + "/" + random_string();
+		TEMP_DIR = Environment.get_tmp_dir() + "/timeshift-" + random_string();
 		dir_create(TEMP_DIR);
 		chmod(TEMP_DIR, "0750");
 		
 		exec_script_sync("echo 'ok'",out std_out,out std_err, true);
 		
 		if ((std_out == null) || (std_out.strip() != "ok")){
-			
-			TEMP_DIR = Environment.get_home_dir() + "/.temp/" + random_string();
+			dir_delete(TEMP_DIR);
+
+			TEMP_DIR = Environment.get_home_dir() + "/.temp/timeshift-" + random_string();
 			dir_create(TEMP_DIR);
 			chmod(TEMP_DIR, "0750");
 		}
-
-		//log_debug("TEMP_DIR=" + TEMP_DIR);
 	}
 
 	public int exec_sync (string cmd, out string? std_out = null, out string? std_err = null){

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -35,7 +35,6 @@ namespace TeeJee.ProcessHelper{
 	// execute process ---------------------------------
 	
     public static void init_tmp(){
-		string std_out, std_err;
 
 		// a list of folders where temp files could be stored
 		string[] tempPlaces = {
@@ -46,6 +45,8 @@ namespace TeeJee.ProcessHelper{
 		};
 
 		foreach (string tempPlace in tempPlaces) {
+			string std_out, std_err;
+
 			TEMP_DIR = tempPlace + "/timeshift-" + random_string();
 			dir_create(TEMP_DIR);
 			chmod(TEMP_DIR, "0750");
@@ -59,6 +60,8 @@ namespace TeeJee.ProcessHelper{
 				return;
 			}
 		}
+
+		stderr.printf("No usable temp directory was found!\n");
 	}
 
 	public int exec_sync (string cmd, out string? std_out = null, out string? std_err = null){

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -34,7 +34,7 @@ namespace TeeJee.ProcessHelper{
 
 	// execute process ---------------------------------
 	
-    public static void init_tmp(string subdir_name){
+    public static void init_tmp(){
 		string std_out, std_err;
 
 		// a list of folders where temp files could be stored

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -203,7 +203,6 @@ namespace TeeJee.ProcessHelper{
 		script.append ("\n");
 		script.append ("%s\n".printf(commands));
 		script.append ("\n\nexitCode=$?\n");
-		script.append ("echo ${exitCode} > ${exitCode}\n");
 		script.append ("echo ${exitCode} > status\n");
 
 		if ((sh_path == null) || (sh_path.length == 0)){


### PR DESCRIPTION
I noticed some aged folders in `/tmp` on my computer.

I first didnt know where they come from. I found a file "0" and "status" inside all of them. So it seems they are from timeshift. To let users know what program created those files (and give the some information to decide if they want to delete those files), I added the string "timeshift" to those folders.

It also seems like the "exitCode file" was not used. But maybe i have overlooked some place?

I think the whole class is a bit weird. Instead of writing every little command into a script and executing that, it might be better to execute some shorter commands directly. Instead of watching the existence of the "status" file its probably beneficial to check for the pid of the specific progress directly. This looks like a job for https://valadoc.org/glib-2.0/GLib.ChildWatchSource.html