### PR TITLE
add lvm-on-luks partition to crypttab

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -2879,11 +2879,19 @@ public class Main : GLib.Object{
 		// check and add entries for mapped devices which are encrypted
 		
 		foreach(var mnt in mount_list){
-			if ((mnt.device != null) && (mnt.device.parent != null) && (mnt.device.is_on_encrypted_partition())){
-				
+			if ((mnt.device != null) && (mnt.device.parent != null)
+				&& ((mnt.device.is_on_encrypted_partition())
+					|| ((mnt.device.parent.parent != null) &&
+						(mnt.device.parent.is_on_encrypted_partition())))){
+
+				// We could be either directly on LUKS or on LVM-on-LUKS,
+				// so be sure to get the top-level LUKS UUID.
+				var crypt_parent = (mnt.device.is_on_encrypted_partition()) ?
+					mnt.device.parent.uuid : mnt.device.parent.parent.uuid;
+
 				// find existing
 				var entry = CryptTabEntry.find_entry_by_uuid(
-					crypttab_list, mnt.device.parent.uuid);
+					crypttab_list, crypt_parent);
 
 				// add if missing
 				if (entry == null){
@@ -2892,8 +2900,8 @@ public class Main : GLib.Object{
 				}
 				
 				// set custom values
-				entry.device_uuid = mnt.device.parent.uuid;
-				entry.mapped_name = "luks-%s".printf(mnt.device.parent.uuid);
+				entry.device_uuid = crypt_parent;
+				entry.mapped_name = "luks-%s".printf(crypt_parent);
 				entry.keyfile = "none";
 				entry.options = "luks,nofail";
 			}


### PR DESCRIPTION
I was trying to restore a snapshot from one Linux Mint installation onto a fresh install. Timeshift would transfer all files, but the restored installation would be unbootable. The boot would hang at the Mint splash screen with a message about how it was waiting for something to provide a particular partition UUID.

The UUID it was waiting for was the LUKS partition on my original installation. Timeshift hadn't updated `/etc/crypttab` with the UUID of my new LUKS partition.

I tracked this down to the fact that the way the Linux Mint installer sets up encryption is LVM-on-LUKS. The LVM layer between LUKS and ext4 caused `Device.is_on_encrypted_partition()` to return `false` when called for my root mount point.

These are the relevant lines of the `lsblk` output that Timeshift used to determine my device layout:
```
NAME="sda3" KNAME="sda3" LABEL="" UUID="65b13e9a-6d8f-4171-a265-db88f13a4c75" TYPE="part" FSTYPE="crypto_LUKS" SIZE="497947770880" MOUNTPOINT="" MODEL="" RO="0" HOTPLUG="0" MAJ:MIN="8:3" PARTLABEL="" PARTUUID="39b0cf2e-601a-4cd3-a2d8-96aaa433d662" PKNAME="sda" VENDOR="" SERIAL="" REV=""
NAME="luks-65b13e9a-6d8f-4171-a265-db88f13a4c75" KNAME="dm-0" LABEL="" UUID="DoB34I-5txT-3nlV-548q-B0Wz-Ox9m-NBt0YG" TYPE="crypt" FSTYPE="LVM2_member" SIZE="497930993664" MOUNTPOINT="" MODEL="" RO="0" HOTPLUG="0" MAJ:MIN="252:0" PARTLABEL="" PARTUUID="" PKNAME="sda3" VENDOR="" SERIAL="" REV=""
NAME="vgmint-root" KNAME="dm-1" LABEL="" UUID="6e019126-e3fd-43d1-af5c-8d3eada27ab7" TYPE="lvm" FSTYPE="ext4" SIZE="495850618880" MOUNTPOINT="/" MODEL="" RO="0" HOTPLUG="0" MAJ:MIN="252:1" PARTLABEL="" PARTUUID="" PKNAME="dm-0" VENDOR="" SERIAL="" REV=""
```

`Device.is_on_encrypted_partition` is looking for `TYPE` to be `crypt`, but for mine it is `lvm`. It's the parent of that partition that has type crypt. That's because it's the grand-parent that is the LUKS partition.

I added the grand-parent check, and then Timeshift correctly updated my `/etc/crypttab`.

I think this change may address the problem noted in #302.