### PR TITLE
Allow explicitly setting ondemand tag from CLI

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1702,6 +1702,9 @@ public class Main : GLib.Object{
 		
 		foreach(string tag in cmd_tags.split(",")){
 			switch(tag.strip().up()){
+			case "O":
+				snapshot.add_tag("ondemand");
+				break;
 			case "B":
 				snapshot.add_tag("boot");
 				break;
@@ -1730,6 +1733,7 @@ public class Main : GLib.Object{
 	public void validate_cmd_tags(){
 		foreach(string tag in cmd_tags.split(",")){
 			switch(tag.strip().up()){
+			case "O":
 			case "B":
 			case "H":
 			case "D":


### PR DESCRIPTION
Fixes #97 

Enables passing `O` to `--tags`.:

```bash
timeshift --create --comments "test O" --tags O
timeshift --create --comments "test O with others" --tags O,H,B
```