### PR TITLE
Always delete btrfs subvolumes recursively

### DIFF
--- a/src/Core/Subvolume.vala
+++ b/src/Core/Subvolume.vala
@@ -140,7 +140,8 @@ public class Subvolume : GLib.Object{
 
 		log_msg("%s: %s (Id:%ld)".printf(_("Deleting subvolume"), name, id));
 
-		string options = App.use_option_raw ? "--commit-after" : "";
+		// always remove subvolumes recursively, this does not affect performance
+		string options = App.use_option_raw ? "--commit-after" : "" + " --recursive";
 		
 		subpath = path_combine(path, name);
 		if (dir_exists(subpath)) { // there is a nested subvol to remove first


### PR DESCRIPTION
This fixes a bug where the "Before restoring" snapshots are not removed due to a deep subvolume nesting. This option ensures that all of the subvolumes are deleted and completely deletes the snapshot. https://imgur.com/a/HS4s3ja