### PR TITLE
only kill a task if its pid is set

### DIFF
--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -433,11 +433,6 @@ public class RsyncTask : AsyncTask{
 		log_debug(string.nfill(70,'='));*/
 		
 		begin();
-
-		if (status == AppStatus.RUNNING){
-			
-			
-		}
 	}
 
 	public override void parse_stdout_line(string out_line){


### PR DESCRIPTION
Fixes: #366

If a user cancels a task, when it was not started, timeshift may try to kill many processes. I also made sure to initilize all values in `AsyncTask` to some sensible defaults.

This results in the estimation task not beeing cancelable. If a user presses cancel, while the estimation is still running, the window will close, but the estimation will continue in the background. Even if timeshift was closed. Solving this is a bit more involved, as it requires to run the rsync process async and storing its pid somewhere. It might be usefull to implement it as `AsyncTask`.