### PR TITLE
Simplify `AsyncTask` code and use `RsyncTask` to estimate Snapshot size

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -228,7 +228,7 @@ public class Main : GLib.Object{
 				file.delete ();
 			}
 
-			dos_log = new DataOutputStream (file.create(FileCreateFlags.REPLACE_DESTINATION));
+			TeeJee.Logging.dos_log = new DataOutputStream (file.create(FileCreateFlags.REPLACE_DESTINATION));
 			if (LOG_DEBUG || gui_mode){
 				log_debug(_("Session log file") + ": %s".printf(log_file));
 			}

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -3997,7 +3997,7 @@ public class Main : GLib.Object{
 		task = new RsyncTask();
 
 		task.dest_path = dir_empty;
-		task.exclude_from_file = save_exclude_list_for_backup(TEMP_DIR) ?? "";;
+		task.exclude_from_file = save_exclude_list_for_backup(TEMP_DIR) ?? "";
 
 		task.delete_extra = true;
 		task.delete_excluded = true;
@@ -4014,7 +4014,7 @@ public class Main : GLib.Object{
 
 		while (task.status == AppStatus.RUNNING){
 			Thread.usleep((ulong) GLib.TimeSpan.MILLISECOND * 16); // ~60fps
-			if(callback != null) callback();
+			if (callback != null) callback();
 			gtk_do_events();
 		}
 

--- a/src/Utility/AsyncTask.vala
+++ b/src/Utility/AsyncTask.vala
@@ -36,7 +36,6 @@ public abstract class AsyncTask : GLib.Object{
 	private DataInputStream dis_out = null;
 	private DataInputStream dis_err = null;
 	protected DataOutputStream dos_log = null;
-	protected bool is_terminated = false;
 
 	private bool stdout_is_open = false;
 	private bool stderr_is_open = false;
@@ -117,7 +116,6 @@ public abstract class AsyncTask : GLib.Object{
 		status = AppStatus.RUNNING;
 		
 		bool has_started = true;
-		is_terminated = false;
 		finish_called = false;
 		
 		prg_count = 0;
@@ -203,7 +201,7 @@ public abstract class AsyncTask : GLib.Object{
 			out_line = dis_out.read_line (null);
 			while (out_line != null) {
 				//log_msg("O: " + out_line);
-				if (!is_terminated && (out_line.length > 0)){
+				if (out_line.length > 0) {
 					parse_stdout_line(out_line);
 					stdout_line_read(out_line); //signal
 				}
@@ -237,7 +235,7 @@ public abstract class AsyncTask : GLib.Object{
 			
 			err_line = dis_err.read_line (null);
 			while (err_line != null) {
-				if (!is_terminated && (err_line.length > 0)){
+				if (err_line.length > 0){
 					error_msg += "%s\n".printf(err_line);
 					
 					parse_stderr_line(err_line);
@@ -568,18 +566,10 @@ public class RsyncTask : AsyncTask{
 	}
 
 	public override void parse_stdout_line(string out_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(out_line);
 	}
 	
 	public override void parse_stderr_line(string err_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(err_line);
 	}
 

--- a/src/Utility/AsyncTask.vala
+++ b/src/Utility/AsyncTask.vala
@@ -342,7 +342,8 @@ public abstract class AsyncTask : GLib.Object{
 		task_complete(); //signal
 	}
 
-	protected abstract void finish_task();
+	// can be overloaded by subclasses, that wish to do special stuff during finish
+	protected virtual void finish_task() {}
 
 	protected int read_exit_code(){
 		
@@ -579,22 +580,6 @@ public class RsyncTask : AsyncTask{
 		}
 
 		return true;
-	}
-
-	protected override void finish_task(){
-		if ((status != AppStatus.CANCELLED) && (status != AppStatus.PASSWORD_REQUIRED)) {
-			status = AppStatus.FINISHED;
-		}
-	}
-
-	public int read_status(){
-		var status_file = working_dir + "/status";
-		var f = File.new_for_path(status_file);
-		if (f.query_exists()){
-			var txt = file_read(status_file);
-			return int.parse(txt);
-		}
-		return -1;
 	}
 }
 */

--- a/src/Utility/AsyncTask.vala
+++ b/src/Utility/AsyncTask.vala
@@ -48,7 +48,6 @@ public abstract class AsyncTask : GLib.Object{
 
 	protected string script_file = "";
 	protected string working_dir = "";
-	protected string log_file = "";
 
 	public bool background_mode = false;
 	
@@ -104,7 +103,6 @@ public abstract class AsyncTask : GLib.Object{
 	protected AsyncTask(){
 		working_dir = TEMP_DIR + "/" + timestamp_for_path();
 		script_file = path_combine(working_dir, "script.sh");
-		log_file = path_combine(working_dir, "task.log");
 
         status_line_mutex = GLib.Mutex();
 
@@ -126,7 +124,7 @@ public abstract class AsyncTask : GLib.Object{
 		
 		bool has_started = true;
 		finish_called = false;
-		
+
 		prg_count = 0;
 		prg_bytes = 0;
 		error_msg = "";
@@ -166,16 +164,6 @@ public abstract class AsyncTask : GLib.Object{
 			dis_err = new DataInputStream(uis_err);
 			dis_out.newline_type = DataStreamNewlineType.ANY;
 			dis_err.newline_type = DataStreamNewlineType.ANY;
-
-			// create log file
-			if (log_file.length > 0){
-				var file = File.new_for_path(log_file);
-				if (file.query_exists()){
-					file.delete();
-				}
-				var file_stream = file.create (FileCreateFlags.REPLACE_DESTINATION);
-				dos_log = new DataOutputStream (file_stream);
-			}
 
 			try {
 				//start thread for reading output stream
@@ -324,19 +312,6 @@ public abstract class AsyncTask : GLib.Object{
 
 		// dispose child process
 		Process.close_pid(child_pid); //required on Windows, doesn't do anything on Unix
-
-		try{
-			// dispose log
-			if ((dos_log != null) && !dos_log.is_closed() && !dos_log.is_closing()){
-				dos_log.close();
-			}
-			dos_log = null;
-		}
-		catch (Error e) {
-			// error can be ignored
-			// dos_log is closed automatically when the last reference is set to null
-			// there may be pending operations which may throw an error
-		}
 
 		read_exit_code();
 		

--- a/src/Utility/DeleteFileTask.vala
+++ b/src/Utility/DeleteFileTask.vala
@@ -144,18 +144,10 @@ public class DeleteFileTask : AsyncTask{
 	}
 
 	public override void parse_stdout_line(string out_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(out_line);
 	}
 	
 	public override void parse_stderr_line(string err_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(err_line);
 	}
 

--- a/src/Utility/DeleteFileTask.vala
+++ b/src/Utility/DeleteFileTask.vala
@@ -179,20 +179,4 @@ public class DeleteFileTask : AsyncTask{
 
 		return true;
 	}
-
-	protected override void finish_task(){
-		if ((status != AppStatus.CANCELLED) && (status != AppStatus.PASSWORD_REQUIRED)) {
-			status = AppStatus.FINISHED;
-		}
-	}
-
-	public int read_status(){
-		var status_file = working_dir + "/status";
-		var f = File.new_for_path(status_file);
-		if (f.query_exists()){
-			var txt = file_read(status_file);
-			return int.parse(txt);
-		}
-		return -1;
-	}
 }

--- a/src/Utility/DeleteFileTask.vala
+++ b/src/Utility/DeleteFileTask.vala
@@ -70,18 +70,14 @@ public class DeleteFileTask : AsyncTask{
 		}
 	}
 
-	public void prepare() {
-		string script_text = build_script();
-		log_debug(script_text);
-		save_bash_script_temp(script_text, script_file);
-
-		log_debug("RsyncTask:prepare(): saved: %s".printf(script_file));
+	public override void prepare() {
+		base.prepare();
 
 		status_line_count = 0;
 		total_size = 0;
 	}
 
-	private string build_script() {
+	protected override string build_script() {
 		var cmd = "";
 
 		if (io_nice){
@@ -126,22 +122,6 @@ public class DeleteFileTask : AsyncTask{
 	}
 
 	// execution ----------------------------
-
-	public void execute() {
-
-		status = AppStatus.RUNNING;
-		
-		log_debug("RsyncTask:execute()");
-		
-		prepare();
-
-		begin();
-
-		if (status == AppStatus.RUNNING){
-			
-			
-		}
-	}
 
 	public override void parse_stdout_line(string out_line){
 		update_progress_parse_console_output(out_line);

--- a/src/Utility/RsyncSpaceCheckTask.vala
+++ b/src/Utility/RsyncSpaceCheckTask.vala
@@ -68,19 +68,14 @@ public class RsyncSpaceCheckTask : AsyncTask{
 		}
 	}
 	
-	public void prepare() {
-		string script_text = build_script();
-		
-		log_debug(script_text);
-		
-		save_bash_script_temp(script_text, script_file);
-		log_debug("RsyncSpaceCheckTask:prepare(): saved: %s".printf(script_file));
+	public override void prepare() {
+		base.prepare();
 
 		total_size = 0;
         status_line_count = 0;
 	}
 
-	private string build_script() {
+	protected override string build_script() {
 		var cmd = "export LC_ALL=C.UTF-8\n";
 
 		cmd += "rsync -aii";
@@ -142,14 +137,6 @@ public class RsyncSpaceCheckTask : AsyncTask{
 	}
 
 	// execution ----------------------------
-
-	public void execute() {
-		
-		log_debug("RsyncSpaceCheckTask:execute()");
-		
-		prepare();
-		begin();
-	}
 
 	public override void parse_stdout_line(string out_line){
 		update_progress_parse_console_output(out_line);

--- a/src/Utility/RsyncSpaceCheckTask.vala
+++ b/src/Utility/RsyncSpaceCheckTask.vala
@@ -152,18 +152,10 @@ public class RsyncSpaceCheckTask : AsyncTask{
 	}
 
 	public override void parse_stdout_line(string out_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(out_line);
 	}
 	
 	public override void parse_stderr_line(string err_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(err_line);
 	}
 

--- a/src/Utility/RsyncSpaceCheckTask.vala
+++ b/src/Utility/RsyncSpaceCheckTask.vala
@@ -182,20 +182,4 @@ public class RsyncSpaceCheckTask : AsyncTask{
 
 		return true;
 	}
-
-	protected override void finish_task(){
-		if ((status != AppStatus.CANCELLED) && (status != AppStatus.PASSWORD_REQUIRED)) {
-			status = AppStatus.FINISHED;
-		}
-	}
-
-	public int read_status(){
-		var status_file = working_dir + "/status";
-		var f = File.new_for_path(status_file);
-		if (f.query_exists()){
-			var txt = file_read(status_file);
-			return int.parse(txt);
-		}
-		return -1;
-	}
 }

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -256,7 +256,7 @@ public class RsyncTask : AsyncTask{
 		source_path = remove_trailing_slash(source_path);
 		
 		dest_path = remove_trailing_slash(dest_path);
-		
+
 		cmd += " '%s/'".printf(escape_single_quote(source_path));
 
 		cmd += " '%s/'".printf(escape_single_quote(dest_path));
@@ -524,7 +524,9 @@ public class RsyncTask : AsyncTask{
 	}
 
 	protected override void finish_task() {
-		file_write(rsync_log_file + "-changes", log.str);
+		if (0 < rsync_log_file.length) {
+			file_write(rsync_log_file + "-changes", log.str);
+		}
 	}
 
 }

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -528,22 +528,8 @@ public class RsyncTask : AsyncTask{
 		return true;
 	}
 
-	protected override void finish_task(){
-		
-		if ((status != AppStatus.CANCELLED) && (status != AppStatus.PASSWORD_REQUIRED)) {
-			status = AppStatus.FINISHED;
-		}
-
+	protected override void finish_task() {
 		file_write(rsync_log_file + "-changes", log.str);
 	}
 
-	public int read_status(){
-		var status_file = working_dir + "/status";
-		var f = File.new_for_path(status_file);
-		if (f.query_exists()){
-			var txt = file_read(status_file);
-			return int.parse(txt);
-		}
-		return -1;
-	}
 }

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -436,18 +436,10 @@ public class RsyncTask : AsyncTask{
 	}
 
 	public override void parse_stdout_line(string out_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(out_line);
 	}
 	
 	public override void parse_stderr_line(string err_line){
-		if (is_terminated) {
-			return;
-		}
-		
 		update_progress_parse_console_output(err_line);
 	}
 

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -136,7 +136,7 @@ public class RsyncTask : AsyncTask{
 
 			regex_list["log-unchanged"] = new Regex(
 				"""[0-9\/]+ [0-9:.]+ \[[0-9]+\] ([.h])([.fdLDS])[ ]{9} (.*)""");
-				
+
 			regex_list["total-size"] = new Regex(
 				"""total size is ([0-9,]+)[ \t]+speedup is [0-9.]+""");
 
@@ -146,13 +146,8 @@ public class RsyncTask : AsyncTask{
 		}
 	}
 	
-	public void prepare() {
-		string script_text = build_script();
-		
-		log_debug(script_text);
-		
-		save_bash_script_temp(script_text, script_file);
-		log_debug("RsyncTask:prepare(): saved: %s".printf(script_file));
+	public override void prepare() {
+		base.prepare();
 
 		//status_lines = new GLib.Queue<string>();
 		status_line_count = 0;
@@ -172,7 +167,7 @@ public class RsyncTask : AsyncTask{
 		log = new StringBuilder();
 	}
 
-	private string build_script() {
+	protected override string build_script() {
 		
 		var cmd = "export LC_ALL=C.UTF-8\n";
 
@@ -419,21 +414,6 @@ public class RsyncTask : AsyncTask{
 	}
 	
 	// execution ----------------------------
-
-	public void execute() {
-		
-		log_debug("RsyncTask:execute()");
-		
-		prepare();
-
-		/*log_debug(string.nfill(70,'='));
-		log_debug(script_file);
-		log_debug(string.nfill(70,'='));
-		log_debug(file_read(script_file));
-		log_debug(string.nfill(70,'='));*/
-		
-		begin();
-	}
 
 	public override void parse_stdout_line(string out_line){
 		update_progress_parse_console_output(out_line);

--- a/src/Utility/TeeJee.FileSystem.vala
+++ b/src/Utility/TeeJee.FileSystem.vala
@@ -171,10 +171,6 @@ namespace TeeJee.FileSystem{
 			dir_create(file_parent(file_path));
 			
 			var file = File.new_for_path (file_path);
-			if (file.query_exists ()) {
-				file.delete ();
-			}
-			
 			var file_stream = file.create (FileCreateFlags.REPLACE_DESTINATION);
 			var data_stream = new DataOutputStream (file_stream);
 			data_stream.put_string (contents);


### PR DESCRIPTION
This continues what i started with #427.
This does not mean #427 is obsolete. #427 still helps to combat a race condition.

What did i do here?
- simplified code for all classes related to `AsyncTask`
  - remove unused (never set to true) `AsyncTask.is_terminated`
  - remove unused (never set) `AsyncTask.log_file`
  - remove unused function `read_status` from Tasks
  - remove other unused functions and members from `AsyncTask`
  - move content of `finish_task` to `AsyncTask` (its code was already contained inside `finish`)
  - make `prepare` virtual and move base implementation to `AsyncTask`
  - move `execute` to `AsyncTask`
  - simplify closing of streams
- make `RsyncTask.regex_list` an array (this avoids stupid typo bugs and i guess its a little not noticeable performance improvement)
- use `RsyncTask` to estimate snapshot size (this is the thing i mentioned in #427) This way it can be canceled and run in the background
- made the estimation use the "pulse" progressbar, since it currently doesn't show any real progress anyways
<img width="500" height="560" alt="grafik" src="https://github.com/user-attachments/assets/2dd5e177-9271-4ea2-b5e5-29818dae872b" />
