### PR TITLE
Fix about links

### DIFF
--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -908,6 +908,9 @@ class MainWindow : Gtk.Window{
 		dialog.set_license_type(Gtk.License.GPL_2_0);
 		dialog.set_website_label("https://github.com/linuxmint/timeshift");
 		dialog.set_website("https://github.com/linuxmint/timeshift");
+
+		// this overwrites the default behaviour of About Dialog
+		dialog.activate_link.connect(TeeJee.System.xdg_open);
 		dialog.run();
 		dialog.destroy();
 	}

--- a/src/Utility/TeeJee.System.vala
+++ b/src/Utility/TeeJee.System.vala
@@ -65,69 +65,9 @@ namespace TeeJee.System{
 		return euid;
 	}
 	
-	public string get_username(){
-
-		// returns actual username of current user (even for applications executed with sudo and pkexec)
-		
-		return get_username_from_uid(get_user_id());
-	}
-
-	public string get_username_effective(){
-
-		// returns effective user id ('root' for applications executed with sudo and pkexec)
-		
-		return get_username_from_uid(get_user_id_effective());
-	}
-
-	public int get_user_id_from_username(string username){
-		
-		// check local user accounts in /etc/passwd -------------------
-
-		foreach(var line in file_read("/etc/passwd").split("\n")){
-			
-			var arr = line.split(":");
-			
-			if ((arr.length >= 3) && (arr[0] == username)){
-				
-				return int.parse(arr[2]);
-			}
-		}
-
-		// not found --------------------
-		
-		log_error("UserId not found for userName: %s".printf(username));
-
-		return -1;
-	}
-
 	public string? get_username_from_uid(int user_id){
 		unowned Posix.Passwd? pw = Posix.getpwuid(user_id);
 		return pw?.pw_name;
-	}
-
-	public string get_user_home(string username = get_username()){
-
-		// check local user accounts in /etc/passwd -------------------
-		
-		foreach(var line in file_read("/etc/passwd").split("\n")){
-			
-			var arr = line.split(":");
-			
-			if ((arr.length >= 6) && (arr[0] == username)){
-
-				return arr[5];
-			}
-		}
-
-		// not found --------------------
-
-		log_error("Home directory not found for user: %s".printf(username));
-
-		return "";
-	}
-
-	public string get_user_home_effective(){
-		return get_user_home(get_username_effective());
 	}
 
 	// system ------------------------------------


### PR DESCRIPTION
Fixes #457

I now overwrite the default behavior of the `AboutDialog` with our own `xdg_open`, that uses the `sudo` or `pkexec` calling user to drop into his environment.
~~I am currently guessing the `DBUS_SESSION_BUS_ADDRESS` (firefox seems to need this to find its open processes). Maybe it would be a good idea to copy the entire env from the parent of pkexec or sudo, when using xdg-open.~~
(EDIT: i was able to drop the guess work due to the merge of #460)

I have also removed some unused user functions, as they can be largely reimplemented with a single line of `Posix.getpwuid(uid)?.pw_dir` or similar if we ever need something like that again.

Shares commits with: #475