### PR TITLE
improve retrieving of session related environment variables

### DIFF
--- a/src/AppConsole.vala
+++ b/src/AppConsole.vala
@@ -75,6 +75,8 @@ public class AppConsole : GLib.Object {
 			return 0;
 		}
 
+		Main.copy_env();
+
 		LOG_ENABLE = false;
 		init_tmp();
 		LOG_ENABLE = true;

--- a/src/AppGtk.vala
+++ b/src/AppGtk.vala
@@ -66,6 +66,8 @@ public class AppGtk : GLib.Object {
 			}
 		}
 
+		Main.copy_env();
+
 		Gtk.init(ref args);
 
 		GTK_INITIALIZED = true;

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -376,6 +376,24 @@ public class Main : GLib.Object{
 		}
 	}
 
+	// copy env from the spawning parent to this
+	public static void copy_env() {
+		Pid user_pid = TeeJee.ProcessHelper.get_user_process();
+		string[]? user_env = TeeJee.ProcessHelper.get_process_env(user_pid);
+		if(user_env == null) {
+			return;
+		}
+
+		// copy all required enviroment vars from the user to this process
+		string[] targets = {"DISPLAY", "XAUTHORITY", "DBUS_SESSION_BUS_ADDRESS"};
+		foreach (string target in targets) {
+			string user_var = TeeJee.ProcessHelper.get_env(user_env, target);
+			if(user_var != null) {
+				GLib.Environment.set_variable(target, user_var, true);
+			}
+		}
+	}
+
     private int[]? get_btrfs_version_array () {
         string stdout;
         string stderr;

--- a/src/Utility/TeeJee.FileSystem.vala
+++ b/src/Utility/TeeJee.FileSystem.vala
@@ -131,6 +131,37 @@ namespace TeeJee.FileSystem{
 	    return null;
 	}
 
+	// read a file with a delimiter into an array
+	// this function is not very optimized so avoid using it for large files
+	public string[]? file_read_array(string file_path, char delimiter = '\n'){
+		try{
+			uint8[] content;
+			GLib.FileUtils.get_data(file_path, out content);
+
+			// count elements
+			string[] parsed = {""};
+			int element = 0;
+			foreach (uint8 byte in content) {
+				// create a new element
+				if(byte == delimiter) {
+					element ++;
+					parsed += "";
+					continue;
+				}
+
+				parsed[element] += ((char) byte).to_string();
+			}
+
+			return parsed;
+		}
+		catch (Error e){
+			log_error (e.message);
+			log_error(_("Failed to read file") + ": %s".printf(file_path));
+		}
+
+		return null;
+	}
+
 	public bool file_write (string file_path, string contents){
 
 		/* Write text to file */

--- a/src/timeshift-launcher
+++ b/src/timeshift-launcher
@@ -9,16 +9,16 @@ else
 	# user is not admin
 	if echo $- | grep "i" >/dev/null 2>&1; then
 		# script is running in interactive mode
-		su - -c "pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY ${app_command}"
+		su - -c "${app_command}"
 	else
 		# script is running in non-interactive mode
 		if [ "$XDG_SESSION_TYPE" = "wayland" ] ; then
 			xhost +SI:localuser:root
-			pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY ${app_command}
+			pkexec "${app_command}"
 			xhost -SI:localuser:root
 			xhost
 		elif command -v pkexec >/dev/null 2>&1; then
-			pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY ${app_command}
+			pkexec "${app_command}"
 		elif command -v sudo >/dev/null 2>&1; then
 			x-terminal-emulator -e "sudo ${app_command}"
 		elif command -v su >/dev/null 2>&1; then


### PR DESCRIPTION
instead of using env in the timeshift-launcher like proposed in #384, the timeshift process itself now searches its parents until it finds a process that is not owned by the same user as timeshift (root) and then copies interesting environment variables from there. This allows pkexec to handle the command correctly.

This should fix: #452
And: #450

It might also be interesting for #459 as it allows us to use the original `$DBUS_SESSION_BUS_ADDRESS`

I know this kinda breaks some principles. But i guess that is the price you have to pay if you want to run a root process in a user session. Maybe timeshift should be moved to a server/client approach (similar to modemmanager) where we have a daemon that is root and a client that can be run by a user and then communicate using system-dbus objects. That would also allow us to have multiple timeshift actions running at the same time. But i guess that would be a bigger topic for another time.