### PR TITLE
add button to pause rsync snapshots

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1647,7 +1647,7 @@ public class Main : GLib.Object{
 
 		task.execute();
 
-		while (task.status == AppStatus.RUNNING){
+		while (this.task.status == AppStatus.RUNNING || this.task.status == AppStatus.PAUSED){
 			sleep(1000);
 			gtk_do_events();
 

--- a/src/Gtk/BackupBox.vala
+++ b/src/Gtk/BackupBox.vala
@@ -131,7 +131,17 @@ class BackupBox : Gtk.Box{
 		lbl_status.max_width_chars = 45;
 		lbl_status.margin_bottom = 6;
 	}
-	
+
+	public void pause() {
+		this.spinner.active = false;
+		this.lbl_msg.set_label(_("Paused"));
+	}
+
+	public void resume() {
+		this.spinner.active = true;
+		this.lbl_msg.set_label("");
+	}
+
 	private Gtk.Label add_count_label(Gtk.Box box, string text,
 		ref Gtk.SizeGroup? sg_label, ref Gtk.SizeGroup? sg_value,
 		int add_margin_bottom = 0){
@@ -264,7 +274,11 @@ class BackupBox : Gtk.Box{
 					#endif
 				}
 
-				lbl_msg.label = escape_html(App.progress_text);
+				if(App.task.status == AppStatus.PAUSED) {
+					lbl_msg.label = _("Paused");
+				} else {
+					lbl_msg.label = escape_html(App.progress_text);
+				}
 
 				if (!checking)
 				{

--- a/src/Gtk/BackupWindow.vala
+++ b/src/Gtk/BackupWindow.vala
@@ -48,6 +48,7 @@ class BackupWindow : Gtk.Window{
 	private Gtk.Button btn_prev;
 	private Gtk.Button btn_next;
 	private Gtk.Button btn_cancel;
+	private Gtk.Button btn_pause;
 	private Gtk.Button btn_close;
 
 	private uint tmr_init;
@@ -188,6 +189,23 @@ class BackupWindow : Gtk.Window{
 			this.destroy(); // TODO: Show error page
 		});
 
+		// pause
+
+		btn_pause = add_button(bbox, _("Pause"), "", size_group, null);
+		btn_pause.clicked.connect(() => {
+			if (App.task != null){
+				if(AppStatus.PAUSED == App.task.status) {
+					App.task.resume();
+					this.backup_box.resume();
+					this.btn_pause.set_label(_("Pause"));
+				} else {
+					App.task.pause();
+					this.backup_box.pause();
+					this.btn_pause.set_label(_("Resume"));
+				}
+			}
+		});
+
 		action_buttons_set_no_show_all(true);
 	}
 
@@ -197,6 +215,7 @@ class BackupWindow : Gtk.Window{
 		btn_next.no_show_all = val;
 		btn_close.no_show_all = val;
 		btn_cancel.no_show_all = val;
+		btn_pause.no_show_all = val;
 	}
 	
 
@@ -274,17 +293,25 @@ class BackupWindow : Gtk.Window{
 		
 		switch(notebook.page){
 		case Tabs.ESTIMATE:
+			btn_prev.hide();
+			btn_next.hide();
+			btn_close.hide();
+			btn_cancel.show();
+			btn_pause.hide();
+			break;
 		case Tabs.BACKUP:
 			btn_prev.hide();
 			btn_next.hide();
 			btn_close.hide();
 			btn_cancel.show();
+			btn_pause.show();
 			break;
 		case Tabs.BACKUP_DEVICE:
 			btn_prev.show();
 			btn_next.show();
 			btn_close.show();
 			btn_cancel.hide();
+			btn_pause.hide();
 			btn_prev.sensitive = false;
 			btn_next.sensitive = true;
 			btn_close.sensitive = true;
@@ -295,6 +322,7 @@ class BackupWindow : Gtk.Window{
 			btn_close.show();
 			btn_close.sensitive = true;
 			btn_cancel.hide();
+			btn_pause.hide();
 			break;
 		}
 

--- a/src/Utility/TeeJee.Misc.vala
+++ b/src/Utility/TeeJee.Misc.vala
@@ -75,7 +75,7 @@ namespace TeeJee.Misc {
 
 	// string formatting -------------------------------------------------
 
-	public string format_duration (long millis){
+	public string format_duration (double millis){
 
 		/* Converts time in milliseconds to format '00:00:00.0' */
 


### PR DESCRIPTION
This adds a button to pause and resume rsync-snapshots.

I added this because of #122 but i dont hink this will solve the problem described in the issue. I dont know where the code for the system tray is located or how i would add a menu to that icon. But i think my work here would help the person implementing such feature.

After the merge of #428, it should be quite simple to add the pause option to the estimation phase as well.

Some screenshots:
<img width="500" height="576" alt="grafik" src="https://github.com/user-attachments/assets/8e702016-8914-45d5-8f6a-092e74c7ce6e" />
<img width="500" height="576" alt="grafik" src="https://github.com/user-attachments/assets/010ea30b-744d-4188-bf7d-df98ad748db8" />
