### PR TITLE
Showing extensive help message hides error message on low resolution screens

### DIFF
--- a/src/AppConsole.vala
+++ b/src/AppConsole.vala
@@ -258,7 +258,7 @@ public class AppConsole : GLib.Object {
 					LOG_TIMESTAMP = false;
 					log_error("%s: %s".printf(
 						_("Invalid command line arguments"), args[k]), true);
-					log_msg(help_message());
+					log_error("Run 'timeshift --help' to list all available options");
 					App.exit_app(1);
 					break;
 			}


### PR DESCRIPTION
On low resolution screens (like a recovery console or tty) printing the entire help message can hide the actual error message (by printing too much text and thus scrolling past the error).

Imo advising to do 'timeshift --help' should be enough.