### PR TITLE
add ioprio_set for background rsync tasks

### DIFF
--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -1659,11 +1659,7 @@ public class Main : GLib.Object{
 		task.delete_extra = true;
 		task.delete_excluded = true;
 		task.delete_after = false;
-
-		if (app_mode.length > 0){
-			// console mode
-			task.io_nice = true;
-		}
+		task.io_nice = (app_mode.length > 0);
 
 		task.execute();
 
@@ -4020,10 +4016,7 @@ public class Main : GLib.Object{
 		task.delete_excluded = true;
 		task.delete_after = false;
 
-		if (app_mode.length > 0){
-			// console mode
-			task.io_nice = true;
-		}
+		task.io_nice = (app_mode.length > 0);
 
 		task.dry_run = true;
 

--- a/src/Utility/DeleteFileTask.vala
+++ b/src/Utility/DeleteFileTask.vala
@@ -33,7 +33,6 @@ public class DeleteFileTask : AsyncTask{
 	// settings
 	public string dest_path = "";
 	public bool verbose = true;
-	public bool io_nice = true;
 	public bool use_rsync = false;
 
 	//private
@@ -79,10 +78,6 @@ public class DeleteFileTask : AsyncTask{
 
 	protected override string build_script() {
 		var cmd = "";
-
-		if (io_nice){
-			//cmd += "ionice -c2 -n7 ";
-		}
 
 		if (use_rsync){
 

--- a/src/Utility/RsyncSpaceCheckTask.vala
+++ b/src/Utility/RsyncSpaceCheckTask.vala
@@ -41,7 +41,6 @@ public class RsyncSpaceCheckTask : AsyncTask{
 	public string source_path = "";
 	public string dest_path = "";
 	public bool verbose = true;
-	public bool io_nice = true;
 	public bool dry_run = false;
 
 	// regex

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -57,7 +57,6 @@ public class RsyncTask : AsyncTask{
 	public string source_path = "";
 	public string dest_path = "";
 	public bool verbose = true;
-	public bool io_nice = true;
 	public bool dry_run = false;
 
 	// regex
@@ -185,10 +184,6 @@ public class RsyncTask : AsyncTask{
 	protected override string build_script() {
 		
 		var cmd = "export LC_ALL=C.UTF-8\n";
-
-		if (io_nice){
-			//cmd += "ionice -c2 -n7 ";
-		}
 
 		cmd += "rsync -aii";
 

--- a/src/Utility/TeeJee.Process.vala
+++ b/src/Utility/TeeJee.Process.vala
@@ -367,7 +367,9 @@ namespace TeeJee.ProcessHelper{
 
 	public Pid[] get_process_children (Pid parent_pid){
 
-		/* Returns the list of child processes owned by a given process */
+		/* Returns the list of child processes owned by a given process
+		   This does not contain grand children
+		*/
 
 		// no explicit check for the existence of /proc/ as this might be a time-of-check-time-of-use bug.
 		File procfs = File.new_for_path("/proc/");
@@ -489,5 +491,18 @@ namespace TeeJee.ProcessHelper{
 		/* Set low priority for process */
 
 		process_set_priority (procID, 5);
+	}
+
+	/*
+		Wrapper for the ioprio_set syscall (has no libc wrapper)
+		see: man 2 ioprio_set
+
+		pid may be 0 (self)
+		prio shall be constructed using IoPrio.prioValue
+		returns true on success
+		sets Posix.errno on error
+	 */
+	public static bool ioprio_set(Pid pid, int prio) {
+		return 0 == IoPrio.syscall(IoPrio.SYS_ioprio_set, IoPrio.IOPRIO_WHO_PROCESS, pid, prio);
 	}
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -95,18 +95,25 @@ sources_app_gtk = files([
   'AppGtk.vala',
 ])
 
+vala_opts = [
+  '--vapidir=' + meson.current_source_dir() / 'vapi',
+  '--pkg', 'ioprio'
+]
+
 timeshift = executable('timeshift',
   sources_app_console + sources_core + sources_utility,
   config_header,
   dependencies: dependencies,
-  install: true
+  install: true,
+  vala_args: vala_opts
 )
 
 timeshift_gtk = executable('timeshift-gtk',
   sources_app_gtk + sources_core + sources_utility + sources_gtk,
   config_header,
   dependencies: dependencies,
-  install: true
+  install: true,
+  vala_args: vala_opts
 )
 
 install_data(

--- a/src/vapi/ioprio.vapi
+++ b/src/vapi/ioprio.vapi
@@ -1,0 +1,33 @@
+
+// iorpio syscalls
+
+[CCode (cprefix = "", lower_case_cprefix = "")]
+namespace IoPrio {
+	[CCode (cheader_filename = "unistd.h", sentinel = "", feature_test_macro = "_DEFAULT_SOURCE")]
+	extern long syscall (long number, ...);
+
+	[CCode (cheader_filename = "sys/syscall.h")]
+	public const int SYS_ioprio_get;
+
+	[CCode (cheader_filename = "sys/syscall.h")]
+	public const int SYS_ioprio_set;
+
+	[CCode (cheader_filename = "linux/ioprio.h")]
+	public const int IOPRIO_WHO_PROCESS;
+
+	[CCode (cheader_filename = "linux/ioprio.h", cname = "int", cprefix = "IOPRIO_CLASS_")]
+	public enum PrioClass {
+		NONE,
+		RT,
+		BE,
+		IDLE,
+		INVALID,
+	}
+
+	/*
+		construct a prio value using a PrioClass and a class specific data attribute
+		See man 2 ioprio_set for details
+	 */
+	[CCode (cheader_filename = "linux/ioprio.h", cname = "IOPRIO_PRIO_VALUE")]
+	extern int prioValue(PrioClass clas, int data);
+}


### PR DESCRIPTION
related to #295

i implemented `ioprio_set` for rsync tasks triggered in the background. I verified it with htop (i configured it to show the io prio).
Starting a gui snapshot, still uses the normal "Best-effort 4" (B4) prio.

I directly used the syscall by providing vala with the correct vapi description. So no external "ionice" binary required, even though its probably present on basically any distro.
For that i closely looked at https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/schedutils/ionice.c