### PR TITLE
Bash completion script

### DIFF
--- a/timeshift-completion.bash
+++ b/timeshift-completion.bash
@@ -1,0 +1,81 @@
+# bash completion for timeshift
+
+_timeshift_snapshots()
+{
+    timeshift --list 2>/dev/null \
+    | awk '
+        /^-+$/ { table=1; next }
+        table && NF >= 3 { print $3 }
+    '
+}
+
+_timeshift()
+{
+    local cur prev opts snaps
+    COMPREPLY=()
+
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+
+    opts='
+        --list
+        --list-snapshots
+        --list-devices
+
+        --check
+        --create
+        --comments
+        --tags
+
+        --restore
+        --snapshot
+        --target
+        --target-device
+        --grub
+        --grub-device
+        --skip-grub
+
+        --delete
+        --delete-all
+
+        --snapshot-device
+        --yes
+        --btrfs
+        --rsync
+        --debug
+        --verbose
+        --quiet
+        --scripted
+        --help
+        --version
+    '
+
+    case "$prev" in
+        --comments|--target|--target-device|--grub|--grub-device|--snapshot-device)
+            return 0
+            ;;
+        --tags)
+            COMPREPLY=( $(compgen -W 'O B H D W M' -- "$cur") )
+            return 0
+            ;;
+        --snapshot)
+            COMPREPLY=()
+            while IFS= read -r s; do
+                COMPREPLY+=( "$(printf '%q' "$s")" )
+            done < <(
+                compgen -W "$(_timeshift_snapshots)" -- "$cur"
+            )
+            return 0
+            ;;
+
+#            snaps=$(_timeshift_snapshots)
+#            COMPREPLY=( $(compgen -W "$snaps" -- "$cur") )
+#            return 0
+#            ;;
+    esac
+
+    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+    return 0
+}
+
+complete -F _timeshift timeshift


### PR DESCRIPTION
# Add bash completion for Timeshift

This adds a bash completion script for Timeshift. It includes:

- Completion for all the main options (`--list`, `--create`, `--restore`, etc.)
- Snapshot name completion for `--snapshot` using `timeshift --list`
- Safe shell quoting for snapshot names (even though Timeshift snapshot names don't contain spaces, this keeps it robust)
- Tag completion for `--tags`

The script is silent if `timeshift --list` fails or if there are no snapshots, so there are no side effects.

This addresses the feature request [FR #502](https://github.com/linuxmint/timeshift/issues/502).

It’s placed in a standard bash-completion style and should work for both user and system-wide installations.

---

## Testing Instructions

1. Copy or link the completion script to your local bash-completion directory:

```bash
# system-wide (requires root)
sudo cp timeshift-completion.bash /etc/bash_completion.d/

# OR user-only
mkdir -p ~/.local/share/bash-completion/completions
sudo cp timeshift-completion.bash ~/.local/share/bash-completion/completions/timeshift
```

2. Reload bash (or source the script directly for quick testing):

```bash
# Reload current shell
source ~/.bashrc

# OR source the script directly
source ./timeshift-completion.bash
```

3. Test completion:

```bash
# Should complete main options
timeshift --<TAB>

# Should complete snapshot names from `timeshift --list`
timeshift --snapshot <TAB>

# Should complete tags for `--tags`
timeshift --tags <TAB>
```

4. Verify that completion is safe and no side effects occur if no snapshots exist.

