### PR TITLE
add comment about the deletion policy

### DIFF
--- a/src/Gtk/SnapshotListBox.vala
+++ b/src/Gtk/SnapshotListBox.vala
@@ -288,7 +288,7 @@ class SnapshotListBox : Gtk.Box{
 						return true;
 					}
 					else if (column == col_desc){
-						tooltip.set_markup(_("<b>Comments</b> (double-click to edit)"));
+						tooltip.set_markup(_("<b>Comments</b> (double-click to edit)") + "\n" + _("Snapshots with comments are not auto-deleted"));
 						return true;
 					}
 					else if (column == col_tags){


### PR DESCRIPTION
Fixes: #463

I just added a comment to the tooltip. Probably not perfect, but better than nothing.

<img width="728" height="306" alt="grafik" src="https://github.com/user-attachments/assets/45bdfc84-735b-4002-be9d-7c64e56f0a82" />

later we should split the "this snapshot should not be deleted" and "this snapshot was user made" logic from one "O" tag to maybe a "U (user)" and "K (Keep)" or similar.