### PR TITLE
MainWindow.vala: Change 'snasphots' typo to 'snapshots'

### DIFF
--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -513,14 +513,14 @@ class MainWindow : Gtk.Window{
 		if (!App.repo.available()){
 			gtk_messagebox(
 				App.repo.status_message,
-				_("Select another device to delete snasphots"),
+				_("Select another device to delete snapshots"),
 				this, false);
 			return;
 		}
 		else if (!App.repo.has_snapshots()){
 			gtk_messagebox(
 				_("No snapshots on device"),
-				_("Select another device to delete snasphots"),
+				_("Select another device to delete snapshots"),
 				this, false);
 			return;
 		}


### PR DESCRIPTION
Fixing a small typo I noticed while using the tool, avoided editing the translation files:

<img width="407" height="120" alt="image" src="https://github.com/user-attachments/assets/2ab9976f-bb7d-45b6-a981-1803834cfacd" />
