### PR TITLE
always drop priviledges when opening a directory

### DIFF
--- a/src/Utility/TeeJee.System.vala
+++ b/src/Utility/TeeJee.System.vala
@@ -115,7 +115,7 @@ namespace TeeJee.System{
 		if (xdg_open_try_first && xdgAvailable){
 			//try using xdg-open
 			string cmd = "xdg-open '%s'".printf(escaped_dir_path);
-			status = exec_script_async (cmd);
+			status = TeeJee.ProcessHelper.exec_user_async(cmd);
 			return (status == 0);
 		}
 
@@ -126,7 +126,7 @@ namespace TeeJee.System{
 			}
 
 			string cmd = "%s '%s'".printf(app_name, escaped_dir_path);
-			status = exec_script_async (cmd);
+			status = TeeJee.ProcessHelper.exec_user_async(cmd);
 
 			if(status == 0) {
 				return true;
@@ -136,7 +136,7 @@ namespace TeeJee.System{
 		if (!xdg_open_try_first && xdgAvailable){
 			//try using xdg-open
 			string cmd = "xdg-open '%s'".printf(escaped_dir_path);
-			status = exec_script_async (cmd);
+			status = TeeJee.ProcessHelper.exec_user_async(cmd);
 			return (status == 0);
 		}
 


### PR DESCRIPTION
Fixes: #517

Always drop privileges when opening a file manager.
- For viewing timeshift logs user privs should be enough.
- For viewing snapshots user prives should mostly also be enough (unless you want to view `/etc/shadow` or other users files, ...)
- users can elevate their privileges on their own if they really need it

EDIT:
Fixes: #520