### PR TITLE
Keep local hardlinks

### DIFF
--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -216,6 +216,8 @@ public class RsyncTask : AsyncTask{
 
 		cmd += " --sparse";
 
+		cmd += " --hard-links";
+
 		//if (relative){
 		//	cmd += " --relative";
 		//}


### PR DESCRIPTION
Fixes issue #542

Adds `--hard-links` to the rsync command to preserve local hard links.