### PR TITLE
Add additional rsync options

### DIFF
--- a/files/timeshift.json
+++ b/files/timeshift.json
@@ -17,6 +17,8 @@
   "count_boot" : "5",
   "snapshot_size" : "0",
   "snapshot_count" : "0",
+  "rsync_no_inc" : "false",
+  "rsync_checksum" : "false",
   "exclude" : [
   ],
   "exclude-apps" : [

--- a/src/Core/Main.vala
+++ b/src/Core/Main.vala
@@ -134,6 +134,8 @@ public class Main : GLib.Object{
 
 	public string date_format = "%Y-%m-%d %H:%M:%S";
 	public const string date_format_default = "%Y-%m-%d %H:%M:%S";
+	public bool rsync_no_inc = false;
+	public bool rsync_checksum = false;
 
 	public Gee.ArrayList<Snapshot> delete_list;
 	
@@ -1665,6 +1667,9 @@ public class Main : GLib.Object{
 		task.rsync_log_file = log_file;
 		task.prg_count_total = Main.first_snapshot_count;
 
+		task.no_inc = rsync_no_inc;
+		task.checksum = rsync_checksum;
+
 		task.relative = true;
 		task.verbose = true;
 		task.delete_extra = true;
@@ -2568,7 +2573,11 @@ public class Main : GLib.Object{
 		if (dry_run){
 			sh += " --dry-run";
 		}
-		
+
+		if (rsync_checksum) {
+			sh += " --checksum";
+		}
+
 		sh += " --log-file=\"%s\"".printf(restore_log_file);
 		sh += " --exclude-from=\"%s\"".printf(restore_exclude_file);
 
@@ -3394,6 +3403,8 @@ public class Main : GLib.Object{
 		}
 
 		config.set_string_member("date_format", date_format);
+		config.set_string_member("rsync_no_inc", rsync_no_inc.to_string());
+		config.set_string_member("rsync_checksum", rsync_checksum.to_string());
 		
 		Json.Array arr = new Json.Array();
 		foreach(string path in exclude_list_user){
@@ -3506,6 +3517,8 @@ public class Main : GLib.Object{
 		this.count_boot = json_get_int(config,"count_boot",count_boot);
 
 		this.date_format = json_get_string(config, "date_format", date_format_default);
+		rsync_no_inc = json_get_bool(config, "rsync_no_inc", rsync_no_inc);
+		rsync_checksum = json_get_bool(config, "rsync_checksum", rsync_checksum);
 
 		Main.first_snapshot_size = json_get_uint64(config,"snapshot_size", Main.first_snapshot_size);
 			

--- a/src/Gtk/MiscBox.vala
+++ b/src/Gtk/MiscBox.vala
@@ -54,11 +54,44 @@ class MiscBox : Gtk.Box{
 		// ------------------------
 		
 		init_date_format_option(vbox);
+		
+		init_rsync_options(vbox);
 
 		refresh();
 		
 		log_debug("MiscBox: MiscBox(): exit");
     }
+	
+	private void init_rsync_options(Gtk.Box box){
+		
+		log_debug("MiscBox: init_rsync_options()");
+		
+		Gtk.Label label_rsync = add_label_header(box, _("Rsync Options"), false);
+		label_rsync.margin_top = 12;
+		label_rsync.margin_bottom = 6;
+		
+		//no_inc_recursive
+		
+		Gtk.CheckButton chk_rsync_no_inc = add_checkbox(this, _("Disable incremental recursion in rsync snapshots"));
+		chk_rsync_no_inc.set_tooltip_text(_("Ensures newly hardlinked files will always be linked with the previous snapshot correctly, at the cost of backups taking significantly longer to start and rsync using significantly more memory. Note that if this option is unchecked, the worst case scenario would only result in a few files being incorrectly marked as new."));
+		
+		chk_rsync_no_inc.active = App.rsync_no_inc;
+		chk_rsync_no_inc.toggled.connect(()=>{
+			App.rsync_no_inc = chk_rsync_no_inc.active;
+		});
+		
+		//checksum
+		
+		Gtk.CheckButton chk_rsync_checksum = add_checkbox(this, _("Compare file checksums in rsync snapshots"));
+		chk_rsync_checksum.set_tooltip_text(_("Compare the contents of all files when creating or restoring snapshots. This can be helpful when you suspect file corruption has occured, but it comes at a massive cost of speed and thus should not be left enabled."));
+		
+		chk_rsync_checksum.active = App.rsync_checksum;
+		chk_rsync_checksum.toggled.connect(()=>{
+			App.rsync_checksum = chk_rsync_checksum.active;
+		});
+		
+		log_debug("MiscBox: init_rsync_options(): exit");
+	}
 
 	private void init_date_format_option(Gtk.Box box){
 

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -216,6 +216,8 @@ public class RsyncTask : AsyncTask{
 
 		cmd += " --sparse";
 
+		cmd += " --hard-links";
+
 		//if (relative){
 		//	cmd += " --relative";
 		//}

--- a/src/Utility/RsyncTask.vala
+++ b/src/Utility/RsyncTask.vala
@@ -51,6 +51,9 @@ public class RsyncTask : AsyncTask{
 	public bool delete_excluded = false;
 	public bool relative = false;
 	
+	public bool no_inc = false;
+	public bool checksum = false;
+	
 	public string rsync_log_file = "";
 	public string exclude_from_file = "";
 	public string link_from_path = "";
@@ -217,6 +220,14 @@ public class RsyncTask : AsyncTask{
 		cmd += " --sparse";
 
 		cmd += " --hard-links";
+
+		if (no_inc) {
+			cmd += " --no-inc-recursive";
+		}
+
+		if (checksum) {
+			cmd += " --checksum";
+		}
 
 		//if (relative){
 		//	cmd += " --relative";


### PR DESCRIPTION
While #546 ensures hard links are remembered, if a new hardlink is found by rsync before the old unchanged file is, rsync will end up treating the group of hardlinked files as if they had been modified/created.
Even in the worst possible case scenario, where no files were modified but a bunch of new hardlinks were created in locations that rsync found first (and each file only had at most 1 new hardlink), this issue could only cause a snapshot to require the same amount of space as it did prior to #546.
I have not created an issue page for this since #546 hasn't been accepted.

This pull request fixes that potential issue by adding an option (that's off by default) in the settings menu (under misc options) to tell rsync to not use incremental recursion (at the cost of snapshot speed and memory).
It also adds a second option (that's also off by default) to tell rsync to compare file checksums when creating/restoring snapshots, which is useful if the user suspects file corruption has occurred (since bit rot is unlikely to change the file's size or modification date).