### PR TITLE
Fix restore failing silently when fstab uses LABEL= entries

### DIFF
--- a/src/Utility/Device.vala
+++ b/src/Utility/Device.vala
@@ -1177,10 +1177,13 @@ public class Device : GLib.Object{
 	public static Device? find_device_in_list(Gee.ArrayList<Device> list, string _dev_alias){
 
 		string dev_alias = _dev_alias;
-		
+
 		if (dev_alias.down().has_prefix("uuid=")){
-			
+
 			dev_alias = dev_alias.split("=",2)[1].strip().down();
+		}
+		else if (dev_alias.down().has_prefix("label=")){
+			dev_alias = dev_alias.split("=",2)[1].strip();
 		}
 		else if (file_exists(dev_alias) && file_is_symlink(dev_alias)){
 
@@ -1226,6 +1229,7 @@ public class Device : GLib.Object{
 			}
 		}
 
+		log_debug("find_device_in_list(): NO MATCH for dev_alias='%s' (checked %d devices)".printf(dev_alias, list.size));
 		return null;
 	}
 	

--- a/src/Utility/FsTabEntry.vala
+++ b/src/Utility/FsTabEntry.vala
@@ -175,6 +175,13 @@ public class FsTabEntry : GLib.Object{
 
 	public bool is_for_system_directory(){
 
+		bool recognized_device_string =
+			device_string.has_prefix("/dev/")
+			|| device_string.down().has_prefix("uuid=")
+			|| device_string.down().has_prefix("label=")
+			|| device_string.down().has_prefix("partuuid=")
+			|| device_string.down().has_prefix("partlabel=");
+
 		if (mount_point.has_prefix("/mnt")
 			|| mount_point.has_prefix("/mount")
 			|| mount_point.has_prefix("/sdcard")
@@ -182,8 +189,8 @@ public class FsTabEntry : GLib.Object{
 			|| mount_point.has_prefix("/media")
 			|| (mount_point == "none")
 			|| !mount_point.has_prefix("/")
-			|| (!device_string.has_prefix("/dev/") && !device_string.down().has_prefix("uuid="))){
-			
+			|| !recognized_device_string){
+
 			return false;
 		}
 		else{


### PR DESCRIPTION
is_for_system_directory() only recognized /dev/* and UUID= device strings, and find_device_in_list() only stripped the UUID= prefix before comparing against known devices. Any fstab entry using LABEL= (the default on Ubuntu cloud images, e.g. LABEL=cloudimg-rootfs) was filtered out before device resolution ever ran, so dst_root was never set.

For --restore --scripted against the currently running system, this meant mount_target_devices() bailed out at its dst_root null-check before the real rsync restore ever started, with no error, a restore that appeared to run but silently did nothing.

Recognize label=/partuuid=/partlabel= alongside /dev/ and uuid= in is_for_system_directory(), and strip label= before comparing in find_device_in_list(), the same way uuid= already is.